### PR TITLE
Update npm scripts, expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,81 @@
 # troposphere-kaizen
 ☁️ how you make the cloud do your bidding 
 
-A [Lore](http://www.lorejs.org) application.
+> This application is built using [Lore](http://www.lorejs.org), a convention-driven framework for 
+React, built on Redux. For an overview of the project structure and architecture, please refer to the Lore 
+documentation. Before beginning development on Troposphere, it's recommended you first complete the 
+[Lore Quickstart](http://www.lorejs.org/quickstart/).
+
+> Before developing on Troposphere, you'll also need to install [Node](https://nodejs.org). If you're on a Mac, we 
+recommend using [nvm](https://github.com/creationix/nvm) to manage your Node installations. If you're on a Windows
+machine, we recommend using [nvm-windows](https://github.com/coreybutler/nvm-windows).
+
+
+## Getting Start
+To get started developing on Troposphere, first clone this repository:
+
+```sh
+git clone https://github.com/lenards/troposphere-kaizen.git
+```
+
+Next install the package dependencies:.
+
+```
+npm install
+```
+
+Finally, start the development server:
+
+```
+npm start
+```
+
+A successful build will produce output similar to this:
+
+```
+webpack-dev-server --history-api-fallback --hot --env=development
+
+Project is running at http://localhost:3000/
+
+webpack output is served from /
+404s will fallback to /index.html
+
+Build completed in 11.5s
+
+Hash: d4d5293a11f211db7080
+Version: webpack 2.4.1
+Time: 11504ms
+
+                 Asset   Size       Chunks                    Chunk Names
+  favicons/favicon.ico   33.3 kB            [emitted]
+ favicon-manifest.json   877 bytes          [emitted]
+assets/images/logo.png   27.7 kB            [emitted]
+        bundle.main.js   4.9 MB          0  [emitted]  [big]  main
+      bundle.vendor.js   1.44 MB         1  [emitted]  [big]  vendor
+            index.html   4.88 kB            [emitted]
+
+...
+
+webpack: Compiled successfully.
+```
+
+At this point you can open up a web browser and navigate to `localhost:3000` and you should see output similar to this:
+
+![troposphere-start-screen-drop-shadow](https://user-images.githubusercontent.com/2637399/33511669-2c7b0e6c-d6dc-11e7-9644-39377765939c.png)
+
+Click the `Login` button in the top right to log into the application.
+
+> *NOTE*: Before developing, you will first need to [create a CyVerse account](https://user.cyverse.org), otherwise
+you won't be able to log in.
+
+
+## Changing the Port of the Development Server 
+The applications runs on port `3000` by default. If you need to change the port, you can do so by modifying 
+the `npm start` command to look like this:
+
+```
+npm start -- --port=3001
+```
+
+That command will instruct the development server to run on port `3001` instead of the default `3000`, and the
+application will now be available on `localhost:3001`.

--- a/package.json
+++ b/package.json
@@ -5,12 +5,16 @@
     "description": "Atmosphere Web Client",
     "keywords": [],
     "scripts": {
-        "build": "npm run clean && webpack --env=production",
-        "build:prod": "npm run clean && webpack --env=production -p",
+        "build": "npm run build:development",
+        "build:development": "npm run clean && webpack --env.webpack=production --env.lore=development",
+        "build:production": "npm run clean && webpack --env.webpack=production --env.lore=production -p",
         "clean": "rimraf dist",
         "server": "json-server --watch db.json --port=1337",
-        "start": "webpack-dev-server --history-api-fallback --hot --env=development --port=3000",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "start": "webpack-dev-server --history-api-fallback --hot --env=development",
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "stats": "npm run stats:development",
+        "stats:development": "webpack --json --env=development > stats.json",
+        "stats:production": "webpack --json --env=production -p > stats.json"
     },
     "dependencies": {
         "axios": "~0.12.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -207,6 +207,9 @@ module.exports = function (env) {
                     yandex: false
                 }
             })
-        ])
+        ]),
+        devServer: {
+            port: 3000
+        }
     };
 };


### PR DESCRIPTION
This PR updates the npm scripts with the following changes:

### README updated!
Steps have been added to the README for people looking for guidance on how to run the project.

### Configurable Port
You can now change the port the development server runs on by typing `npm start -- --port-3001`. The default port is still `3000`, but this allows you to override it easily.

### Two-tiered Build Setup
If you look at any of the `npm build` scripts, you'll notice two `env` variables, being `env.webpack` and `env.lore`:

```
webpack --env.webpack=production --env.lore=development
```

The `env.lore` variable controls which environment the project targets (development, staging, production, etc) from the perspective of _behavior_ (what servers it talks to, what feature flags are active, etc.) 

The `env.webpack` variable controls the `NODE_ENV` variable, which determines things like which "mode" libraries run in, whether errors are suppressed, and also whether CSS is extracted into an external file (among other behaviors).

The reason for having two switches is so that you can run a production build against your local development environment (for example, to test whether minification and bundling is correct), or maybe you might want to run a development version of the code (non-minified) on a staging server for some reason (perhaps to see warnings and errors that would otherwise be suppressed).

### Webpack Stats
If you run `npm run stats` it will generate a `stats.json` file which gives information about the generated bundles, their sizes, and what libraries they include (and how big those libraries are).

This file is especially useful for visualizing the package size via the [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/), which can help inform you about actions to take to reduce the overall size of the application (such as by tree-shaking or replacing large libraries).