### PR TITLE
Add Image Tags Page

### DIFF
--- a/cyverse-ui-next/MediaCardSection.js
+++ b/cyverse-ui-next/MediaCardSection.js
@@ -22,7 +22,7 @@ export default createReactClass({
             position: 'absolute',
             left: left,
             right: right,
-            maxWidth: width || '100%'
+            width: width || '100%'
         };
     },
 

--- a/cyverse-ui-next/MediaCardText.js
+++ b/cyverse-ui-next/MediaCardText.js
@@ -6,30 +6,40 @@ export default createReactClass({
     displayName: 'MediaCardText',
 
     propTypes: {
-        text: PropTypes.string.isRequired
+        text: PropTypes.string.isRequired,
+        maxCharacters:  PropTypes.number
+    },
+
+    getDefaultProps() {
+      return {
+          maxCharacters: 100
+      }
     },
 
     getStyles(text) {
+        const { maxCharacters } = this.props;
+
         return {
             color: 'rgba(0, 0, 0, 0.67)',
             marginTop: '18px',
             marginBottom: '18px',
             maxHeight: '36px',
             overflow: 'hidden',
-            lineHeight: text.length < 50 ? '36px' : '18px'
+            lineHeight: text.length < maxCharacters/2 ? '36px' : '18px'
         };
     },
 
     render: function () {
         let {
-            text
+            text,
+            maxCharacters
         } = this.props;
 
         const styles = this.getStyles(text);
 
         return (
             <div style={styles}>
-                {text.length > 103 ? `${text.slice(0, 100)}...` : text}
+                {text.length > (maxCharacters + 3) ? `${text.slice(0, maxCharacters)}...` : text}
             </div>
         );
     }

--- a/routes.js
+++ b/routes.js
@@ -28,6 +28,7 @@ import ImageSearchAllLayout from './src/components/images-search-all/Layout';
 import ImageSearchFeaturedLayout from './src/components/images-search-featured/Layout';
 import ImageSearchFavoritesLayout from './src/components/images-search-favorites/Layout';
 import ImageSearchMineLayout from './src/components/images-search-mine/Layout';
+import ImageTagsLayout from './src/components/images-tags/Layout';
 
 // Placeholder Route
 import Placeholder from './src/components/_common/Header';
@@ -51,7 +52,7 @@ export default (
                         <Route path="favorites" component={ImageSearchFavoritesLayout} />
                         <Route path="mine" component={ImageSearchMineLayout} />
                     </Route>
-                    <Route path="tags" component={() => <div />} />
+                    <Route path="tags" component={ImageTagsLayout} />
                     <Route path="my-image-requests" component={() => <div />} />
                 </Route>
             </Route>

--- a/src/components/_common/IsStaff.js
+++ b/src/components/_common/IsStaff.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import PayloadStates from '../../constants/PayloadStates';
+
+export default createReactClass({
+    displayName: 'IsStaff',
+
+    contextTypes: {
+        user: PropTypes.object.isRequired
+    },
+
+    render: function () {
+        const {
+            user
+        } = this.context;
+
+        const {
+            children,
+            ...other
+        } = this.props;
+
+        if (
+            user.state !== PayloadStates.ERROR_FETCHING &&
+            user.data.is_staff === true
+        ) {
+            return React.Children.map(children, (child) => {
+                return React.cloneElement(child, {...other});
+            });
+        }
+
+        return null;
+    }
+
+});

--- a/src/components/images-tags/Header.js
+++ b/src/components/images-tags/Header.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import { ActionInfo } from 'material-ui/svg-icons';
+
+const styles = {
+    container: {
+        marginBottom: '32px'
+    },
+    title: {
+        fontSize: '24px',
+        fontWeight: 'bold',
+        letterSpacing: '1px'
+    },
+    iconWrapper: {
+        display: 'inline-block',
+        lineHeight: '72px',
+        verticalAlign: 'top',
+        marginRight: '8px'
+    },
+    textWrapper: {
+        display: 'inline-block'
+    },
+    description: {
+        color: 'rgba(0,0,0,.67)',
+        fontSize: '16px',
+        fontWeight: '400',
+        maxWidth: '600px',
+        lineHeight: '24px',
+        margin: '0px'
+    }
+};
+
+export default createReactClass({
+    displayName: 'Layout',
+
+    render: function () {
+        return (
+            <div style={styles.container}>
+                <h1 style={styles.title}>
+                    Explore image tags
+                </h1>
+                <div>
+                    <div style={styles.iconWrapper}>
+                        <ActionInfo />
+                    </div>
+                    <div style={styles.textWrapper}>
+                        <p style={styles.description}>
+                            Explore the tags used to categorize images. Click on a tag to search for images that
+                            have that tag applied.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+});

--- a/src/components/images-tags/Layout.js
+++ b/src/components/images-tags/Layout.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import Header from './Header';
+import SearchBar from './SearchBar';
+import Tags from './Tags';
+import FloatingActionButton from '../projects/FloatingActionButton';
+import CreateTagDialog from '../../dialogs/tag/create';
+import IsStaff from '../_common/IsStaff';
+
+const styles = {
+    container: {
+        position :'relative'
+    },
+    floatingActionButton: {
+        top: '-28px'
+    },
+    page: {
+        paddingTop: '32px'
+    }
+};
+
+export default createReactClass({
+    displayName: 'Layout',
+
+    contextTypes: {
+        user: PropTypes.object.isRequired
+    },
+
+    onSearch: function(searchTerm) {
+        const {
+            router,
+            location
+        } = this.props;
+
+        router.push({
+            pathname: location.pathname,
+            query: _.merge({}, location.query, {
+                search: searchTerm
+            })
+        });
+    },
+
+    render: function () {
+        const { location } = this.props;
+        const { user } = this.context;
+
+        return (
+            <div className="container" style={styles.container}>
+                <IsStaff>
+                    <FloatingActionButton
+                        style={styles.floatingActionButton}
+                        onClick={() => {
+                            lore.dialog.show(() => {
+                                return (
+                                    <CreateTagDialog />
+                                );
+                            });
+                        }}
+                    />
+                </IsStaff>
+                <div style={styles.page}>
+                    <Header />
+                    <SearchBar onSearch={this.onSearch} />
+                    <Tags query={{ tag: location.query.tag }}/>
+                </div>
+            </div>
+        );
+    }
+
+});

--- a/src/components/images-tags/SearchBar.js
+++ b/src/components/images-tags/SearchBar.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import _ from 'lodash';
+import { SearchBar } from 'cyverse-ui';
+import { withRouter } from 'react-router';
+
+export default withRouter(createReactClass({
+    displayName: 'SearchBar',
+
+    propTypes: {
+        onSearch: PropTypes.func.isRequired
+    },
+
+    getInitialState: function() {
+        const { location } = this.props;
+
+        this.onSearch = _.debounce(this.onSearch, 250);
+        return {
+            search: location.query.tag || ''
+        }
+    },
+
+    onChange: function(e) {
+        const value = e.target.value;
+        this.setState({
+            search: value
+        });
+        this.onSearch(value);
+    },
+
+    onSearch: function(searchTerm) {
+        const {
+            router,
+            location
+        } = this.props;
+
+        router.push({
+            pathname: location.pathname,
+            query: _.merge({}, location.query, {
+                tag: searchTerm
+            })
+        });
+    },
+
+    render: function() {
+        const { search } = this.state;
+
+        return (
+            <SearchBar
+                placeholder="Search Tags"
+                value={search}
+                onChange={this.onChange}
+                // onClear={() => {}}
+            />
+        );
+    }
+
+}));

--- a/src/components/images-tags/Tag.js
+++ b/src/components/images-tags/Tag.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+import { ListItem, IconMenu, IconButton, MenuItem } from 'material-ui';
+import { NavigationMoreVert, EditorModeEdit, ActionDelete } from 'material-ui/svg-icons';
+import UpdateTagDialog from '../../dialogs/tag/update';
+import DestroyTagDialog from '../../dialogs/tag/destroy';
+import IsStaff from '../_common/IsStaff';
+import PayloadStates from '../../constants/PayloadStates';
+
+// const styles = {
+//     anchorOrigin: {
+//         horizontal: 'right',
+//         vertical: 'bottom'
+//     },
+//     targetOrigin: {
+//         horizontal: 'right',
+//         vertical: 'top'
+//     }
+// };
+
+export default withRouter(createReactClass({
+    displayName: 'Tag',
+
+    propTypes: {
+        tag: PropTypes.object.isRequired,
+        router: PropTypes.object.isRequired
+    },
+
+    onClick() {
+        const { tag, router } = this.props;
+        router.push({
+            pathname: '/images/search/all',
+            query: {
+                search: tag.data.name
+            }
+        })
+    },
+
+    getStyles: function() {
+        const { tag } = this.props;
+
+        const styles = {
+            listItem:  {},
+            iconMenu: {
+                anchorOrigin: {
+                    horizontal: 'right',
+                    vertical: 'bottom'
+                },
+                targetOrigin: {
+                    horizontal: 'right',
+                    vertical: 'top'
+                }
+            }
+        };
+
+        if (
+            tag.state === PayloadStates.CREATING ||
+            tag.state === PayloadStates.UPDATING ||
+            tag.state === PayloadStates.DELETING
+        ) {
+            styles.listItem.opacity ='0.3';
+        }
+
+        return styles;
+    },
+
+    render: function () {
+        const { tag } = this.props;
+        const styles = this.getStyles();
+
+        return (
+            <ListItem
+                key={tag.id || tag.cid}
+                style={styles.listItem}
+                primaryText={tag.data.name}
+                secondaryText={tag.data.description}
+                rightIconButton={(
+                    <IsStaff>
+                        <IconMenu
+                            iconButtonElement={(
+                                <IconButton>
+                                    <NavigationMoreVert/>
+                                </IconButton>
+                            )}
+                            anchorOrigin={styles.anchorOrigin}
+                            targetOrigin={styles.targetOrigin}
+                        >
+                            <MenuItem
+                                primaryText="Edit"
+                                leftIcon={<EditorModeEdit/>}
+                                onClick={() => {
+                                    lore.dialog.show(() => {
+                                        return (
+                                            <UpdateTagDialog model={tag} />
+                                        );
+                                    });
+                                }}
+                            />
+                            <MenuItem
+                                primaryText="Delete"
+                                leftIcon={<ActionDelete/>}
+                                onClick={() => {
+                                    lore.dialog.show(() => {
+                                        return (
+                                            <DestroyTagDialog model={tag} />
+                                        );
+                                    });
+                                }}
+                            />
+                        </IconMenu>
+                    </IsStaff>
+                )}
+                onClick={this.onClick}
+            />
+        );
+    }
+}));

--- a/src/components/images-tags/Tags.js
+++ b/src/components/images-tags/Tags.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import { Paper, Divider, List } from 'material-ui';
+import { SkeletonList } from 'cyverse-ui';
+import _ from 'lodash';
+import { connect } from 'lore-hook-connect';
+import InfiniteScrolling from '../../decorators/InfiniteScrolling';
+import PayloadStates from '../../constants/PayloadStates';
+import Tag from './Tag';
+import LoadMoreButton from '../images-search/_common/LoadMoreButton';
+import ListHeader from '../images-search/_common/ListHeader';
+
+export default connect(function(getState, props) {
+    const query = props.query || {};
+
+    return {
+        tags: getState('tag.find', {
+            where: query,
+            pagination: {
+                page: '1',
+                page_size: 10
+            }
+        }, { forceFetchOnMount: true })
+    };
+})(
+InfiniteScrolling({ propName: 'tags', modelName: 'tag' })(
+createReactClass({
+    displayName: 'Tags',
+
+    propTypes: {
+        query: PropTypes.object.isRequired,
+        pages: PropTypes.array.isRequired,
+        onLoadMore: PropTypes.func.isRequired
+    },
+
+    render: function () {
+        const {
+            query,
+            pages,
+            onLoadMore
+        } = this.props;
+        const numberOfPages = pages.length;
+        const firstPage = pages[0];
+        const lastPage = pages[pages.length - 1];
+
+        // if we only have one page, and it's fetching, then it's the initial
+        // page load so let the user know we're loading the data
+        if (numberOfPages === 1 && lastPage.state === PayloadStates.FETCHING) {
+            return (
+                <div>
+                    <ListHeader>
+                        {query.search ? `Searching for "${query.search}"` : `Searching...`}
+                    </ListHeader>
+                    <SkeletonList cardCount={4} />
+                </div>
+            );
+        }
+
+        const tagListItems = _.flatten(pages.map((tags, pageIndex) => {
+            if (tags.state === PayloadStates.FETCHING) {
+                return [];
+            }
+
+            return _.flatten(tags.data.map((tag, index) => {
+                const items = [(
+                    <Tag
+                        key={tag.id || tag.cid}
+                        tag={tag}
+                    />
+                )];
+
+                if (true || index < (tags.data.length - 1)) {
+                    items.push(
+                        <Divider key={`divider-${tag.id || tag.cid}`}/>
+                    );
+                }
+
+                return items;
+            }))
+        }));
+
+        let title = '';
+
+        if (!firstPage.meta || !firstPage.meta.totalCount) {
+            title = `Showing ${tagListItems.length/2} tags`;
+        } else if (query.search) {
+            title = `Showing ${tagListItems.length/2} tags for "${query.search}"`;
+        } else {
+            title = `Showing ${tagListItems.length/2} of ${firstPage.meta.totalCount} tags`;
+        }
+
+        return (
+            <div>
+                <ListHeader>
+                    {title}
+                </ListHeader>
+                <Paper>
+                    <List style={{ padding: '0px' }}>
+                        {tagListItems}
+                    </List>
+                </Paper>
+                <LoadMoreButton
+                    label="Show More Tags"
+                    lastPage={lastPage}
+                    onLoadMore={() => {
+                        onLoadMore({
+                            forceFetch: true
+                        })
+                    }}
+                    nextPageMetaField="nextPage"
+                />
+            </div>
+        );
+    }
+
+})
+)
+);

--- a/src/components/projects/FloatingActionButton.js
+++ b/src/components/projects/FloatingActionButton.js
@@ -1,14 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
+import _ from 'lodash';
 import { FloatingActionButton } from 'material-ui';
 import { ContentAdd } from 'material-ui/svg-icons';
-
-const styles = {
-    position: 'absolute',
-    top: '50%',
-    right: 15
-};
 
 export default createReactClass({
     displayName: 'FloatingActionButton',
@@ -17,8 +12,19 @@ export default createReactClass({
         onClick: PropTypes.func.isRequired
     },
 
+    getStyles() {
+        const { style } = this.props;
+
+        return _.merge({
+            position: 'absolute',
+            top: '50%',
+            right: 15
+        }, style);
+    },
+
     render: function () {
         const { onClick } = this.props;
+        const styles = this.getStyles();
 
         return (
             <FloatingActionButton

--- a/src/components/projects/Project.js
+++ b/src/components/projects/Project.js
@@ -110,7 +110,7 @@ createReactClass({
                         />
                     </MediaCardIcons>
                 </MediaCardSection>
-                <MediaCardSection right="0%">
+                <MediaCardSection right="0%" width="inherit">
                     <MediaCardMenu>
                         <MenuItem primaryText="Edit" leftIcon={<EditorModeEdit/>} onClick={() => {
                             lore.dialog.show(() => {

--- a/src/dialogs/tag/create.js
+++ b/src/dialogs/tag/create.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import Dialog from '../../../src/decorators/Dialog';
+import OverlayTemplate from '../_templates/OverlayTemplate';
+import validators from '../../utils/validators';
+
+export default Dialog()(createReactClass({
+    displayName: 'Tag/Create',
+
+    propTypes: {
+        onCancel: PropTypes.func.isRequired
+    },
+
+    contextTypes: {
+        user: PropTypes.object.isRequired
+    },
+
+    request: function (data) {
+        const { user } = this.context;
+        return lore.actions.tag.create(data).payload;
+    },
+
+    render: function () {
+        const {
+            onSubmit,
+            onCancel
+        } = this.props;
+
+        const {
+            schemas,
+            fieldMap,
+            actionMap
+        } = lore.config.dialogs;
+
+        return (
+            <OverlayTemplate
+                schema={schemas.default}
+                fieldMap={fieldMap}
+                actionMap={actionMap}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+                config={{
+                    props: {
+                        title: 'Create Tag',
+                        subtitle: 'Fill out the form to create a tag',
+                        // information: 'This is an informational message',
+                        successMessage: {
+                            title: 'Success!',
+                            message: 'Tag created.'
+                        },
+                        reducer: 'tag',
+                        request: this.request
+                    },
+                    data: {
+                        name: '',
+                        description: '',
+                    },
+                    validators: {
+                        name: [validators.isRequired],
+                        description: [validators.isRequired]
+                    },
+                    fields: {
+                        name: {
+                            type: 'string',
+                            props: {
+                                floatingLabelText: 'Name'
+                            }
+                        },
+                        description: {
+                            type: 'text',
+                            props: {
+                                floatingLabelText: 'Description'
+                            }
+                        },
+                    },
+                    actions: [
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Cancel',
+                                    onTouchTap: () => {
+                                        form.callbacks.onCancel()
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Create',
+                                    primary: true,
+                                    disabled: form.hasError,
+                                    onTouchTap: () => {
+                                        form.callbacks.onSubmit(form.data)
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }}
+            />
+        );
+    }
+
+}));

--- a/src/dialogs/tag/destroy.js
+++ b/src/dialogs/tag/destroy.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import Dialog from '../../../src/decorators/Dialog';
+import OverlayTemplate from '../_templates/OverlayTemplate';
+import validators from '../../utils/validators';
+
+export default Dialog()(createReactClass({
+    displayName: 'Tag/Destroy',
+
+    propTypes: {
+        model: PropTypes.object.isRequired,
+        onCancel: PropTypes.func.isRequired
+    },
+
+    request: function (data) {
+        const { model } = this.props;
+        return lore.actions.tag.destroy(model).payload;
+    },
+
+    render: function () {
+        const {
+            model,
+            onSubmit,
+            onCancel
+        } = this.props;
+
+        const {
+            schemas,
+            fieldMap,
+            actionMap
+        } = lore.config.dialogs;
+
+        return (
+            <OverlayTemplate
+                model={model}
+                schema={schemas.default}
+                fieldMap={fieldMap}
+                actionMap={actionMap}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+                config={{
+                    props: (form) => {
+                        return {
+                            title: 'Destroy Tag',
+                            // subtitle: `Submit this form to destroy this ${modelName}`,
+                            information: 'This action is irreversible',
+                            successMessage: {
+                                title: 'Success!',
+                                message: 'Tag destroyed.'
+                            },
+                            reducer: 'tag',
+                            request: this.request
+                        }
+                    },
+                    validators: {},
+                    fields: {
+                        confirm: {
+                            type: 'custom',
+                            props: (form) => {
+                                return {
+                                    render: () => {
+                                        return (
+                                            <div>
+                                                Are you sure you want to delete this tag?
+                                            </div>
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    actions: [
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Cancel',
+                                    onTouchTap: () => {
+                                        form.callbacks.onCancel()
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Destroy',
+                                    primary: true,
+                                    disabled: form.hasError,
+                                    onTouchTap: () => {
+                                        form.callbacks.onSubmit(form.data)
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }}
+            />
+        );
+    }
+
+}));

--- a/src/dialogs/tag/update.js
+++ b/src/dialogs/tag/update.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import Dialog from '../../../src/decorators/Dialog';
+import OverlayTemplate from '../_templates/OverlayTemplate';
+import validators from '../../utils/validators';
+
+export default Dialog()(createReactClass({
+    displayName: 'Tag/Update',
+
+    propTypes: {
+        model: PropTypes.object.isRequired,
+        onCancel: PropTypes.func.isRequired
+    },
+
+    request: function (data) {
+        const { model } = this.props;
+        return lore.actions.tag.update(model, data).payload;
+    },
+
+    render: function () {
+        const {
+            model,
+            onSubmit,
+            onCancel
+        } = this.props;
+
+        const {
+            schemas,
+            fieldMap,
+            actionMap
+        } = lore.config.dialogs;
+
+        return (
+            <OverlayTemplate
+                model={model}
+                schema={schemas.default}
+                fieldMap={fieldMap}
+                actionMap={actionMap}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+                config={{
+                    props: {
+                        title: 'Update Tag',
+                        subtitle: 'Fill out the form to update the tag',
+                        // information: 'This is an informational message',
+                        successMessage: {
+                            title: 'Success!',
+                            message: 'Tag updated.'
+                        },
+                        reducer: 'tag',
+                        request: this.request
+                    },
+                    data: {
+                        name: '',
+                        description: '',
+                    },
+                    validators: {
+                        name: [validators.isRequired],
+                        description: [validators.isRequired]
+                    },
+                    fields: {
+                        name: {
+                            type: 'string',
+                            props: {
+                                floatingLabelText: 'Name'
+                            }
+                        },
+                        description: {
+                            type: 'text',
+                            props: {
+                                floatingLabelText: 'Description'
+                            }
+                        },
+                    },
+                    actions: [
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Cancel',
+                                    onTouchTap: () => {
+                                        form.callbacks.onCancel()
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Update',
+                                    primary: true,
+                                    disabled: form.hasError,
+                                    onTouchTap: () => {
+                                        form.callbacks.onSubmit(form.data)
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }}
+            />
+        );
+    }
+
+}));

--- a/src/models/tag.js
+++ b/src/models/tag.js
@@ -1,0 +1,80 @@
+export default {
+
+  properties: {
+
+    /**
+     * Override the idAttribute if the primary key in the resource is named
+     * anything other than 'id'. Doing so will allow the other methods to
+     * behave as expected, such as composing the expected url for CRUD
+     * operations and being able to retrieve the primary key by 'model.id'
+     */
+
+    // idAttribute: 'id'
+
+    /**
+     * Override the initialize method if you need to save data for use
+     * in other functions. This is especially useful if you have a nested
+     * URL for an API endpoint, like /authors/:userId/books. In that case,
+     * you can save the author here and refer to it when creating the URL
+     * in the url() or urlRoot() method.
+     */
+
+    // initialize: function(attributes, options) {
+    //   return;
+    // },
+
+    /**
+     * Override the urlRoot if your API endpoint does not match the default
+     * conventions. For example, given a model named 'bookAuthor', and assuming
+     * an apiRoot of 'http://localhost:1337' with pluralize set to true, the
+     * endpoint for creating a model is assumed to be 'http://localhost:1337/bookAuthors'
+     * If this model is on a different server (such as http://localhost:3001) or the
+     * endpoint is named something different (such as book_authors or books/:id/authors)
+     * you will need to set that here; urlRoot can be either a string or a function
+     */
+
+    // urlRoot: function() {
+    //   return 'https://api.example.com/endpoint'
+    // },
+
+    /**
+     * Override the url method if you need complete control over the final URL
+     * endpoint. This is especially useful when you have an endpoint like /user
+     * or /profile that returns a single resource with information about the current
+     * user and an id is not required. You'll also need to override this method if
+     * the route doesn't use the primary key of the resource.
+     */
+
+    // url: function() {
+    //   return 'https://api.example.com/unconventional/endpoint/123'
+    // },
+
+    /**
+     * Override the parse method if you need to modify data before using
+     * it in the application, such as converting timestamps or adding
+     * properties to absorb breaking API changes.
+     */
+
+    // parse: function(resp, options) {
+    //   return resp;
+    // },
+
+    /**
+     * Override the sync method if you need to modify data before sending
+     * it to the server.
+     *
+     * If you override this method the library will make no AJAX requests
+     * for this model, so you'll need to make sure you implement the AJAX
+     * call yourself or make a call to sync.apply(this, arguments).
+     *
+     * Use of 'sync' refers to sync method provided by the 'lore-models'
+     * package, i.e. import { sync } from 'lore-models'
+     */
+
+    // sync: function() {
+    //   return sync.apply(this, arguments);
+    // }
+
+  }
+
+}


### PR DESCRIPTION
This PR adds the Image Tags page with a search experience.

# Visual Demonstration
Here is a 9 MB GIF showing what the dialogs do when an error occurs (may need to give it a minute to load).

![image-tags-low-res](https://user-images.githubusercontent.com/2637399/33869500-3931e846-dec6-11e7-90c1-5fc76f2c367f.gif)

# Key Callouts
Here are some things worth highlighting.

## Configured for search, not full-page index
The page is currently configured to support server-side search, and *NOT* display all tags on a single page. I don't believe this page is designed yet (?) so it's unclear whether we want to keep the experience or switch to a traditional search experience (as opposed to displaying all ~500 tags on a single page.

If we DO want to support a traditional search experience, this is problematic because the `/api/v2/tags` endpoint does not currently support search, though it does support pagination (takeaway = we need to enable search if we want to support a server-side search experience).

## Search results registered as URL
Searching for a tag saves the query in the url under `?tag=xyz_pqr`. Refreshing the page will show the same search results.

## Clicking tag navigates to search results
Clicking on a tag will change the url to `/images/search/all?search=tag_name`, piggybacking on the existing search functionality. In the future, once a query language is supported, this can be modified to whatever syntax means "only show images that have this tag".

## Admin-only dialogs for creating, editing and deleting tags
There are dialogs for creating, editing and deleting a tag. These dialogs are _*only visible to admins*_. Public and Authenticated users can't see them. I don't know what the real tag experience looks like, or whether we need/want this ability in the real application, but I wanted to demonstrate that including them is a fairly low level of effort when using the `OverlayTemplate`, and also because it seems like a "nice to have".

