### PR TITLE
Add Volume Actions and Dialogs

### DIFF
--- a/blueprints/actions/volumeAction.js
+++ b/blueprints/actions/volumeAction.js
@@ -1,0 +1,118 @@
+import _ from 'lodash';
+import { ActionTypes, normalize } from 'lore-utils';
+import { getState } from 'lore-hook-connect';
+import Poll from 'lore-hook-polling/es/Poll';
+import PayloadStates from '../../src/constants/PayloadStates';
+import updateV1 from '../../src/actions/volume/updateV1';
+import get from '../../src/actions/volume/get';
+import getV1 from '../../src/actions/volumeV1/get';
+
+/*
+ * Blueprint for Update method
+ */
+export default function(options) {
+    if (!options.params) {
+        throw new Error('Missing params')
+    }
+
+    if (!options.params.action) {
+        throw new Error('Missing params.action')
+    }
+
+    if (!options.optimisticState) {
+        throw new Error('Missing optimisticState')
+    }
+
+    return function update(model, params) {
+        return function (dispatch) {
+            const { instance } = params;
+            const Model = lore.models.instanceActionV1;
+            const proxyModel = new Model(_.pick(instance.data, [
+                'provider_uuid',
+                'identity_uuid',
+                'uuid'
+            ]));
+            proxyModel.set(_.merge({}, options.params, {
+                volume_id: model.data.uuid
+            }));
+
+            const originalState = _.merge({}, model.data.state);
+            const optimisticState = {
+                status_raw: options.optimisticState.status_raw,
+                status: options.optimisticState.status,
+                activity: options.optimisticState.activity
+            };
+
+            proxyModel.save().then(function () {
+                dispatch({
+                    type: ActionTypes.update('volume'),
+                    payload: _.merge(model, {
+                        data: {
+                            state: optimisticState
+                        },
+                        state: PayloadStates.MANAGED
+                    })
+                });
+
+                const poll = new Poll(updateV1(model).bind(null, function(action) {
+                    const volume = action.payload;
+                    if (volume.state === PayloadStates.RESOLVED) {
+                        if (volume.data.state.status_raw !== originalState.status_raw) {
+                            poll.stop();
+
+                            dispatch({
+                                type: ActionTypes.update('volume'),
+                                payload: _.merge(model, {
+                                    data: {
+                                        attach_data: volume.data.attach_data,
+                                        state: volume.data.state
+                                    },
+                                    state: PayloadStates.RESOLVED
+                                })
+                            });
+
+                            dispatch(action);
+                        }
+                    }
+                }), {});
+
+                poll.start();
+
+            }).catch(function (response) {
+                const error = response.data;
+
+                if (response.status === 404) {
+                    dispatch({
+                        type: ActionTypes.update('volume'),
+                        payload: _.merge(model, {
+                            data: {
+                                state: originalState
+                            },
+                            state: PayloadStates.NOT_FOUND,
+                            error: error
+                        })
+                    });
+                } else {
+                    dispatch({
+                        type: ActionTypes.update('volume'),
+                        payload: _.merge(model, {
+                            data: {
+                                state: originalState
+                            },
+                            state: PayloadStates.ERROR_UPDATING,
+                            error: error
+                        })
+                    });
+                }
+            });
+
+            return dispatch({
+                type: ActionTypes.update('volume'),
+                payload: _.merge(model, {
+                    // data: proxyModel.toJSON(),
+                    state: PayloadStates.UPDATING
+                })
+            });
+        };
+    }
+};

--- a/src/actions/volume/attach.js
+++ b/src/actions/volume/attach.js
@@ -1,0 +1,12 @@
+import volumeAction from '../../../blueprints/actions/volumeAction';
+
+export default volumeAction({
+    params: {
+        action: 'attach_volume'
+    },
+    optimisticState: {
+        status_raw: "attaching",
+        status: "attaching",
+        activity: ""
+    }
+});

--- a/src/actions/volume/detach.js
+++ b/src/actions/volume/detach.js
@@ -1,0 +1,12 @@
+import volumeAction from '../../../blueprints/actions/volumeAction';
+
+export default volumeAction({
+    params: {
+        action: 'detach_volume'
+    },
+    optimisticState: {
+        status_raw: "detaching",
+        status: "detaching",
+        activity: ""
+    }
+});

--- a/src/actions/volume/get.js
+++ b/src/actions/volume/get.js
@@ -1,0 +1,65 @@
+import _ from 'lodash';
+import { ActionTypes, PayloadStates, payload, normalize } from 'lore-utils';
+import getV1 from '../volumeV1/get';
+
+/*
+ * Blueprint for Get method
+ */
+export default function get(modelId, query = {}) {
+    return function(dispatch) {
+        const Model = lore.models.volume;
+        const model = new Model({
+            id: modelId
+        });
+
+        model.fetch({
+            data: query
+        }).then(function() {
+            // fetch the volume data from the v1 endpoint - we're going to extend
+            // our volume model with data we commonly need across the application
+            getV1(model.attributes)(function(action) {
+                const volumeV1 = action.payload;
+                if (volumeV1.state === PayloadStates.RESOLVED) {
+
+                    // look through the model and generate actions for any attributes with
+                    // nested data that should be normalized
+                    const actions = normalize(lore, 'volume').model(model);
+
+                    // modify volume with data from volumeV1 we want to extend it with
+                    _.extend(model.attributes, volumeV1.data);
+
+                    // dispatch the modified volume
+                    dispatch({
+                        type: ActionTypes.update('volume'),
+                        payload: payload(model, PayloadStates.RESOLVED)
+                    });
+
+                    // dispatch any actions created from normalizing nested data
+                    actions.forEach(dispatch);
+                }
+            });
+        }).catch(function(response) {
+            const error = response.data;
+
+            if (response.status === 404) {
+                dispatch({
+                    type: ActionTypes.update('volume'),
+                    payload: _.merge(payload(model), {
+                        state: PayloadStates.NOT_FOUND,
+                        error: error
+                    })
+                });
+            } else {
+                dispatch({
+                    type: ActionTypes.update('volume'),
+                    payload: payload(model, PayloadStates.ERROR_FETCHING, error)
+                });
+            }
+        });
+
+        return dispatch({
+            type: ActionTypes.add('volume'),
+            payload: payload(model, PayloadStates.FETCHING)
+        });
+    };
+};

--- a/src/actions/volume/updateV1.js
+++ b/src/actions/volume/updateV1.js
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+import { ActionTypes, PayloadStates, normalize } from 'lore-utils';
+
+/*
+ * Blueprint for UpdateV1 method
+ */
+export default function update(model, params = {}) {
+    return function (dispatch) {
+        const Model = lore.models.volumeV1;
+        const proxyModel = new Model(model.data);
+        proxyModel.set(params);
+
+        proxyModel.fetch().then(function () {
+            dispatch({
+                type: ActionTypes.update('volume'),
+                payload: _.merge(model, {
+                    data: proxyModel.toJSON(),
+                    state: PayloadStates.RESOLVED
+                })
+            });
+        }).catch(function (response) {
+            const error = response.data;
+
+            if (response.status === 404) {
+                dispatch({
+                    type: ActionTypes.update('volume'),
+                    payload: _.merge(model, {
+                        state: PayloadStates.NOT_FOUND,
+                        error: error
+                    })
+                });
+            } else {
+                dispatch({
+                    type: ActionTypes.update('volume'),
+                    payload: _.merge(model, {
+                        data: proxyModel.toJSON(),
+                        state: PayloadStates.ERROR_UPDATING,
+                        error: error
+                    })
+                });
+            }
+        });
+
+        return dispatch({
+            type: ActionTypes.update('volume'),
+            payload: _.merge(model, {
+                data: proxyModel.toJSON(),
+                state: PayloadStates.UPDATING
+            })
+        });
+    };
+};

--- a/src/actions/volumeV1/get.js
+++ b/src/actions/volumeV1/get.js
@@ -17,17 +17,10 @@ export default function get(modelId, query = {}) {
         model.fetch({
             data: query
         }).then(function() {
-            // look through the model and generate actions for any attributes with
-            // nested data that should be normalized
-            const actions = normalize(lore, 'volumeV1').model(model);
-
             dispatch({
                 type: ActionTypes.update('volumeV1'),
                 payload: payload(model, PayloadStates.RESOLVED)
             });
-
-            // dispatch any actions created from normalizing nested data
-            actions.forEach(dispatch);
         }).catch(function(response) {
             const error = response.data;
 

--- a/src/components/_common/ExternalLink.js
+++ b/src/components/_common/ExternalLink.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+
+export default createReactClass({
+    displayName: 'ExternalLink',
+
+    propTypes: {
+        href: PropTypes.string.isRequired,
+        children: PropTypes.node.isRequired
+    },
+
+    contextTypes: {
+      muiTheme: PropTypes.object.isRequired
+    },
+
+    render: function () {
+        const {
+            href,
+            children
+        } = this.props;
+
+        const { muiTheme } = this.context;
+
+        return (
+            <a href={href} target="_blank" style={{ color: muiTheme.palette.primary1Color }}>
+                {children}
+            </a>
+        );
+    }
+
+});

--- a/src/components/project-volumes/ProjectVolumes.js
+++ b/src/components/project-volumes/ProjectVolumes.js
@@ -40,7 +40,8 @@ createReactClass({
     render: function () {
         const {
             pages,
-            onLoadMore
+            onLoadMore,
+            project
         } = this.props;
         const numberOfPages = pages.length;
         const firstPage = pages[0];
@@ -85,6 +86,7 @@ createReactClass({
                                 <Volume
                                     key={volume.id || volume.cid}
                                     volume={volume}
+                                    project={project}
                                 />
                             );
                         }}

--- a/src/components/project-volumes/Volume/Menu.old.js
+++ b/src/components/project-volumes/Volume/Menu.old.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import { MenuItem, Divider } from 'material-ui';
+import {
+    ActionDelete,
+    FileFolder,
+    EditorModeEdit,
+    NavigationChevronLeft
+} from 'material-ui/svg-icons';
+import {
+    IntercomIcon
+} from 'cyverse-ui/es/icons';
+import { connect } from 'lore-hook-connect';
+import { MediaCardMenu } from 'cyverse-ui-next';
+import PayloadStates from '../../../constants/PayloadStates';
+import AttachVolumeDialog from '../../../dialogs/volume/attach';
+import DetachVolumeDialog from '../../../dialogs/volume/detach';
+
+export default createReactClass({
+    displayName: 'Menu',
+
+    propTypes: {
+        volume: PropTypes.object.isRequired
+    },
+
+    getStyles: function() {
+        const { volume } = this.props;
+
+        if (
+            volume.state === PayloadStates.CREATING ||
+            volume.state === PayloadStates.UPDATING ||
+            volume.state === PayloadStates.DELETING
+        ) {
+            return {
+              opacity: '0.3'
+            }
+        }
+
+        return {};
+    },
+
+    actionEnabled(actionName) {
+        const {actions} = this.props;
+
+        return !!_.find(actions.data, (action) => {
+            return action.data.name === actionName;
+        })
+    },
+
+    render: function () {
+        const { volume } = this.props;
+        const styles = this.getStyles();
+
+        return (
+            <MediaCardMenu>
+                <MenuItem
+                    primaryText="Actions"
+                    leftIcon={<NavigationChevronLeft />}
+                    menuItems={[
+                        <MenuItem
+                            primaryText="Attach"
+                            // leftIcon={<IntercomIcon />}
+                            // disabled={!this.actionEnabled('Reboot')}
+                            onClick={() => {
+                                lore.dialog.show(() => {
+                                    return (
+                                        <AttachVolumeDialog model={volume} />
+                                    );
+                                });
+                            }}
+                        />,
+                        <MenuItem
+                            primaryText="Detach"
+                            // leftIcon={<IntercomIcon />}
+                            // disabled={!this.actionEnabled('Redeploy')}
+                            onClick={() => {
+                                lore.dialog.show(() => {
+                                    return (
+                                        <DetachVolumeDialog model={volume} />
+                                    );
+                                });
+                            }}
+                        />
+                    ]}
+                />
+                <Divider />
+                <MenuItem
+                    primaryText="Report"
+                    leftIcon={<IntercomIcon />}
+                    disabled={true}
+                />
+                <MenuItem
+                    primaryText="Delete"
+                    leftIcon={<ActionDelete />}
+                    disabled={true}
+                />
+                <MenuItem
+                    primaryText="Move Volume"
+                    leftIcon={<FileFolder />}
+                    disabled={true}
+                />
+                <MenuItem
+                    primaryText="Edit"
+                    leftIcon={<EditorModeEdit />}
+                    disabled={true}
+                />
+            </MediaCardMenu>
+        );
+    }
+});

--- a/src/components/project-volumes/Volume/Menu/AttachMenuItem.js
+++ b/src/components/project-volumes/Volume/Menu/AttachMenuItem.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import { MenuItem } from 'material-ui';
+import { connect, Connect } from 'lore-hook-connect';
+import PayloadStates from '../../../../constants/PayloadStates';
+import AttachVolumeDialog from '../../../../dialogs/volume/attach';
+
+const DetachMenuItem = createReactClass({
+    displayName: 'AttachMenuItem',
+
+    propTypes: {
+        volume: PropTypes.object.isRequired,
+        project: PropTypes.object.isRequired
+    },
+
+    render: function () {
+        const {
+            volume,
+            project
+        } = this.props;
+
+        if (volume.data.state.status === 'available') {
+            return (
+                <MenuItem
+                    primaryText="Attach"
+                    // leftIcon={<IntercomIcon />}
+                    disabled={false}
+                    onClick={() => {
+                        lore.dialog.show(() => {
+                            return (
+                                <AttachVolumeDialog
+                                    model={volume}
+                                    project={project}
+                                />
+                            );
+                        });
+                    }}
+                />
+            );
+        }
+
+        return (
+            <MenuItem
+                primaryText="Attach"
+                // leftIcon={<IntercomIcon />}
+                disabled={true}
+            />
+        );
+    }
+});
+
+DetachMenuItem.muiName = 'MenuItem';
+
+export default DetachMenuItem;

--- a/src/components/project-volumes/Volume/Menu/DetachMenuItem.js
+++ b/src/components/project-volumes/Volume/Menu/DetachMenuItem.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import { MenuItem } from 'material-ui';
+import { connect, Connect } from 'lore-hook-connect';
+import PayloadStates from '../../../../constants/PayloadStates';
+import DetachVolumeDialog from '../../../../dialogs/volume/detach';
+
+const DetachMenuItem = createReactClass({
+    displayName: 'DetachMenuItem',
+
+    propTypes: {
+        volume: PropTypes.object.isRequired
+    },
+
+    actionEnabled(actionName) {
+        const { actions } = this.props;
+
+        return !!_.find(actions.data, (action) => {
+            return action.data.name === actionName;
+        })
+    },
+
+    render: function () {
+        const { volume } = this.props;
+
+        if (volume.data.state.status_raw === 'in-use') {
+            return (
+                <Connect callback={(getState, props) => {
+                    return {
+                        instanceV1: getState('instanceV1.byIdV1', {
+                            uuid: volume.data.attach_data.instance_alias,
+                            provider_uuid: volume.data.provider_uuid,
+                            identity_uuid: volume.data.identity_uuid
+                        })
+                    }
+                }}>
+                    {(props) => {
+                        const { instanceV1 } = props;
+
+                        return (
+                            <MenuItem
+                                primaryText="Detach"
+                                // leftIcon={<IntercomIcon />}
+                                // disabled={!this.actionEnabled('Redeploy')}
+                                onClick={() => {
+                                    lore.dialog.show(() => {
+                                        return (
+                                            <DetachVolumeDialog
+                                                model={volume}
+                                                instance={instanceV1}
+                                            />
+                                        );
+                                    });
+                                }}
+                            />
+                        );
+                    }}
+                </Connect>
+            );
+        }
+
+        return (
+            <MenuItem
+                primaryText="Detach"
+                // leftIcon={<IntercomIcon />}
+                disabled={true}
+            />
+        );
+    }
+});
+
+DetachMenuItem.muiName = 'MenuItem';
+
+export default DetachMenuItem;

--- a/src/components/project-volumes/Volume/Menu/index.js
+++ b/src/components/project-volumes/Volume/Menu/index.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import { MenuItem, Divider } from 'material-ui';
+import {
+    ActionDelete,
+    FileFolder,
+    EditorModeEdit,
+    NavigationChevronLeft
+} from 'material-ui/svg-icons';
+import {
+    IntercomIcon
+} from 'cyverse-ui/es/icons';
+import { MediaCardMenu } from 'cyverse-ui-next';
+import AttachMenuItem from './AttachMenuItem';
+import DetachMenuItem from './DetachMenuItem';
+
+export default createReactClass({
+    displayName: 'Menu',
+
+    propTypes: {
+        volume: PropTypes.object.isRequired
+    },
+
+    render: function () {
+        const { volume, project } = this.props;
+
+        return (
+            <MediaCardMenu>
+                <MenuItem
+                    primaryText="Actions"
+                    leftIcon={<NavigationChevronLeft />}
+                    menuItems={[
+                        <AttachMenuItem
+                            volume={volume}
+                            project={project}
+                        />,
+                        <DetachMenuItem volume={volume} />
+                    ]}
+                />
+                <Divider />
+                <MenuItem
+                    primaryText="Report"
+                    leftIcon={<IntercomIcon />}
+                    disabled={true}
+                />
+                <MenuItem
+                    primaryText="Delete"
+                    leftIcon={<ActionDelete />}
+                    disabled={true}
+                />
+                <MenuItem
+                    primaryText="Move Volume"
+                    leftIcon={<FileFolder />}
+                    disabled={true}
+                />
+                <MenuItem
+                    primaryText="Edit"
+                    leftIcon={<EditorModeEdit />}
+                    disabled={true}
+                />
+            </MediaCardMenu>
+        );
+    }
+});

--- a/src/components/project-volumes/Volume/Polling.js
+++ b/src/components/project-volumes/Volume/Polling.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import { connect } from 'lore-hook-connect';
+import PayloadStates from '../../../constants/PayloadStates';
+import volumeUtils from '../../../utils/volume';
+
+export default createReactClass({
+    displayName: 'Polling',
+
+    propTypes: {
+        volume: PropTypes.object.isRequired
+    },
+
+    componentDidMount() {
+        const { volume } = this.props;
+        this.startPolling(volume);
+    },
+
+    componentWillUnmount() {
+        if (this.poll) {
+            this.poll.stop();
+        }
+    },
+
+    componentWillReceiveProps(nextProps) {
+        const { volume } = nextProps;
+        this.startPolling(volume);
+        this.stopPolling(volume);
+    },
+
+    startPolling(volume) {
+        if (
+            !this.poll &&
+            !volumeUtils(volume).isInFinalState() &&
+            volume.state !== PayloadStates.MANAGED
+        ) {
+            this.poll = lore.polling.volume.get(volume.id);
+            this.poll.start();
+        }
+    },
+
+    stopPolling(volume) {
+        if (
+            this.poll &&
+            this.poll.isPolling &&
+            volumeUtils(volume).isInFinalState() &&
+            volume.state !== PayloadStates.MANAGED
+        ) {
+            this.poll.stop();
+        }
+    },
+
+    render: function() {
+        return null;
+    }
+});

--- a/src/components/project-volumes/Volume/Status.js
+++ b/src/components/project-volumes/Volume/Status.js
@@ -21,31 +21,17 @@ const styles = {
     }
 };
 
-export default connect(function(getState, props) {
-    const { volume } = props;
-
-    return {
-        volumeV1: getState('volumeV1.byIdV1', {
-            uuid: volume.data.uuid,
-            provider_uuid: volume.data.provider_uuid,
-            identity_uuid: volume.data.identity_uuid
-        })
-    }
-})(
-createReactClass({
+export default createReactClass({
     displayName: 'Status',
 
     propTypes: {
-        volumeV1: PropTypes.object.isRequired
+        volume: PropTypes.object.isRequired
     },
 
     render: function () {
-        const {
-            volume,
-            volumeV1
-        } = this.props;
+        const { volume } = this.props;
 
-        if (volumeV1.state === PayloadStates.FETCHING) {
+        if (volume.state === PayloadStates.FETCHING) {
             return (
                 <div style={styles.largePadding}>
                     ...
@@ -53,7 +39,7 @@ createReactClass({
             );
         }
 
-        if (volumeV1.data.status === 'available') {
+        if (volume.data.state.status === 'available') {
             return (
                 <div style={styles.largePadding}>
                     <StatusLight status="active" /> <span style={styles.text}>Unattached</span>
@@ -61,12 +47,12 @@ createReactClass({
             );
         }
 
-        if (volumeV1.data.status === 'in-use') {
+        if (volume.data.state.status === 'in-use') {
             return (
                 <Connect callback={(getState, props) => {
                     return {
                         instanceV1: getState('instanceV1.byIdV1', {
-                            uuid: volumeV1.data.attach_data.instance_alias,
+                            uuid: volume.data.attach_data.instance_alias,
                             provider_uuid: volume.data.provider_uuid,
                             identity_uuid: volume.data.identity_uuid
                         })
@@ -74,7 +60,6 @@ createReactClass({
                 }}>
                     {(props) => {
                         const { instanceV1 } = props;
-                        const percentComplete = volumeUtils(volumeV1).getPercentComplete();
 
                         if (instanceV1.state === PayloadStates.FETCHING) {
                             return (
@@ -84,24 +69,9 @@ createReactClass({
                             );
                         }
 
-                        if (!percentComplete || percentComplete === 100) {
-                            return (
-                                <div style={styles.largePadding}>
-                                    <StatusLight status="active" /> <span style={styles.text}>{`Attached to ${instanceV1.data.name}`}</span>
-                                </div>
-                            );
-                        }
-
                         return (
-                            <div style={styles.smallPadding}>
-                                <div style={{ marginBottom: '8px' }}>
-                                    <StatusLight status="transition" /> <span style={styles.text}>{volumeV1.data.status}</span>
-                                </div>
-                                <LinearProgress
-                                    mode="determinate"
-                                    value={percentComplete}
-                                    style={{ maxWidth: '80%' }}
-                                />
+                            <div style={styles.largePadding}>
+                                <StatusLight status="active" /> <span>{`Attached to ${instanceV1.data.name}`}</span>
                             </div>
                         );
                     }}
@@ -109,12 +79,19 @@ createReactClass({
             );
         }
 
+        const percentComplete = volumeUtils(volume).getPercentComplete();
 
         return (
-            <div style={styles.largePadding}>
-                <StatusLight status="transition" /> <span style={styles.text}>Unattached</span>
+            <div style={styles.smallPadding}>
+                <div style={{ marginBottom: '8px' }}>
+                    <StatusLight status="transition" /> <span style={styles.text}>{volume.data.state.status}</span>
+                </div>
+                <LinearProgress
+                    mode="determinate"
+                    value={percentComplete}
+                    style={{ maxWidth: '80%' }}
+                />
             </div>
         );
     }
-})
-);
+});

--- a/src/components/project-volumes/Volume/index.js
+++ b/src/components/project-volumes/Volume/index.js
@@ -1,31 +1,24 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { MenuItem } from 'material-ui';
-import {
-    ActionDelete,
-    FileFolder,
-    EditorModeEdit
-} from 'material-ui/svg-icons';
-import {
-    IntercomIcon
-} from 'cyverse-ui/es/icons';
 import {
     MediaCard,
-    MediaCardSection,
-    MediaCardMenu
+    MediaCardSection
 } from 'cyverse-ui-next';
 import PayloadStates from '../../../constants/PayloadStates';
 import Identity from './Identity';
 import Status from './Status';
 import Size from './Size';
 import Provider from './Provider';
+import Menu from './Menu';
+import Polling from './Polling';
 
 export default createReactClass({
     displayName: 'Volume',
 
     propTypes: {
-        volume: PropTypes.object.isRequired
+        volume: PropTypes.object.isRequired,
+        project: PropTypes.object.isRequired
     },
 
     getStyles: function() {
@@ -48,12 +41,14 @@ export default createReactClass({
 
     render: function () {
         const {
-            volume
+            volume,
+            project
         } = this.props;
         const styles = this.getStyles();
 
         return (
             <MediaCard style={styles}>
+                <Polling volume={volume} />
                 <MediaCardSection width="30%">
                     <Identity volume={volume} />
                 </MediaCardSection>
@@ -67,28 +62,10 @@ export default createReactClass({
                     <Provider volume={volume} />
                 </MediaCardSection>
                 <MediaCardSection right="0%" width="inherit">
-                    <MediaCardMenu>
-                        <MenuItem
-                            primaryText="Report"
-                            leftIcon={<IntercomIcon />}
-                            disabled={true}
-                        />
-                        <MenuItem
-                            primaryText="Delete"
-                            leftIcon={<ActionDelete />}
-                            disabled={true}
-                        />
-                        <MenuItem
-                            primaryText="Move Volume"
-                            leftIcon={<FileFolder />}
-                            disabled={true}
-                        />
-                        <MenuItem
-                            primaryText="Edit"
-                            leftIcon={<EditorModeEdit />}
-                            disabled={true}
-                        />
-                    </MediaCardMenu>
+                    <Menu
+                        volume={volume}
+                        project={project}
+                    />
                 </MediaCardSection>
             </MediaCard>
         );

--- a/src/dialogs/volume/attach.js
+++ b/src/dialogs/volume/attach.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import { getState } from 'lore-hook-connect';
+import Dialog from '../../../src/decorators/Dialog';
+import OverlayTemplate from '../_templates/OverlayTemplate';
+import validators from '../../utils/validators';
+
+export default Dialog()(createReactClass({
+    displayName: 'Volume/Attach',
+
+    propTypes: {
+        model: PropTypes.object.isRequired,
+        project: PropTypes.object.isRequired,
+        onCancel: PropTypes.func.isRequired
+    },
+
+    request: function (data) {
+        const { model } = this.props;
+        const instance = getState('instance.byId', {
+            id: data.instance_id
+        });
+        return lore.actions.volume.attach(model, {
+            instance: instance
+        }).payload;
+    },
+
+    render: function () {
+        const {
+            model,
+            project,
+            onSubmit,
+            onCancel
+        } = this.props;
+
+        const {
+            schemas,
+            fieldMap,
+            actionMap
+        } = lore.config.dialogs;
+
+        return (
+            <OverlayTemplate
+                model={model}
+                schema={schemas.default}
+                fieldMap={fieldMap}
+                actionMap={actionMap}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+                config={{
+                    props: (form) => {
+                        return {
+                            title: 'Attach Volume',
+                            // subtitle: `Submit this form to destroy this ${modelName}`,
+                            information: `Select the instance that you would like to attach the volume to`,
+                            successMessage: {
+                                title: 'Success!',
+                                message: 'Volume attached.'
+                            },
+                            reducer: 'volume',
+                            request: this.request
+                        }
+                    },
+                    validators: {
+                        instance_id: [validators.number.isRequired]
+                    },
+                    fields: {
+                        instance_id: {
+                            type: 'select',
+                            props: {
+                                floatingLabelText: 'Instance',
+                                field: 'name',
+                                options: (getState, props) => {
+                                    return getState('instance.findAll', {
+                                        exclude: {
+                                            where: function(instance) {
+                                                return (
+                                                    instance.data.project !== project.id ||
+                                                    instance.data.provider !== model.data.provider
+                                                );
+                                            }
+                                        }
+                                    })
+                                }
+                            }
+                        }
+                    },
+                    actions: [
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Cancel',
+                                    onTouchTap: () => {
+                                        form.callbacks.onCancel()
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Attach',
+                                    primary: true,
+                                    disabled: form.hasError,
+                                    onTouchTap: () => {
+                                        form.callbacks.onSubmit(form.data)
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }}
+            />
+        );
+    }
+
+}));

--- a/src/dialogs/volume/detach.js
+++ b/src/dialogs/volume/detach.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import Dialog from '../../../src/decorators/Dialog';
+import OverlayTemplate from '../_templates/OverlayTemplate';
+import validators from '../../utils/validators';
+import ExternalLink from '../../components/_common/ExternalLink';
+
+export default Dialog()(createReactClass({
+    displayName: 'Volume/Detach',
+
+    propTypes: {
+        model: PropTypes.object.isRequired,
+        instance: PropTypes.object.isRequired,
+        onCancel: PropTypes.func.isRequired
+    },
+
+    request: function (data) {
+        const { model, instance } = this.props;
+        return lore.actions.volume.detach(model, {
+            instance: instance
+        }).payload;
+    },
+
+    render: function () {
+        const {
+            model,
+            onSubmit,
+            onCancel
+        } = this.props;
+
+        const {
+            schemas,
+            fieldMap,
+            actionMap
+        } = lore.config.dialogs;
+
+        return (
+            <OverlayTemplate
+                model={model}
+                schema={schemas.default}
+                fieldMap={fieldMap}
+                actionMap={actionMap}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+                config={{
+                    props: (form) => {
+                        return {
+                            title: 'Detach Volume',
+                            // subtitle: `Submit this form to destroy this ${modelName}`,
+                            information: `WARNING If data is being written to the volume when it's detached, the data may become corrupted. Therefore, we recommend you make sure there is no data being written to the volume before detaching it.`,
+                            successMessage: {
+                                title: 'Success!',
+                                message: 'Volume detached.'
+                            },
+                            reducer: 'volume',
+                            request: this.request
+                        }
+                    },
+                    validators: {},
+                    fields: {
+                        confirm: {
+                            type: 'custom',
+                            props: (form) => {
+                                return {
+                                    render: () => {
+                                        return (
+                                            <div>
+                                                <div style={{ marginBottom: '16px' }}>
+                                                    Would you like to detach this volume?
+                                                </div>
+                                                <div>
+                                                    <ExternalLink href="https://pods.iplantcollaborative.org/wiki/display/atmman/Attaching+and+Detaching+Volumes">
+                                                        Learn more about unmounting and detaching a volume
+                                                    </ExternalLink>
+                                                </div>
+                                            </div>
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    actions: [
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Cancel',
+                                    onTouchTap: () => {
+                                        form.callbacks.onCancel()
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            type: 'raised',
+                            props: (form) => {
+                                return {
+                                    label: 'Detach',
+                                    primary: true,
+                                    disabled: form.hasError,
+                                    onTouchTap: () => {
+                                        form.callbacks.onSubmit(form.data)
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }}
+            />
+        );
+    }
+
+}));

--- a/src/models/instance.js
+++ b/src/models/instance.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 export default {
 
     attributes: {
@@ -74,6 +76,11 @@ export default {
                 status: resp.status.split(" - ")[0],
                 activity: resp.activity
             };
+
+            if (_.isPlainObject(resp.project)) {
+                resp.project = resp.project.id;
+            }
+
             return resp;
         },
 

--- a/src/models/volumeV1.js
+++ b/src/models/volumeV1.js
@@ -65,9 +65,17 @@ export default {
          * properties to absorb breaking API changes.
          */
 
-        // parse: function(resp, options) {
-        //   return resp;
-        // },
+        parse: function(resp, options) {
+            resp.state = {
+                status_raw: resp.status,
+                status: resp.status.split(" - ")[0],
+                activity: resp.status.split(" - ")[1] || ''
+            };
+            return _.pick(resp, [
+                'attach_data',
+                'state'
+            ]);
+        },
 
         /**
          * Override the sync method if you need to modify data before sending

--- a/src/utils/volume.js
+++ b/src/utils/volume.js
@@ -17,7 +17,7 @@ export default function(volume) {
     const {
         status,
         activity
-    } = volume.data;
+    } = volume.data.state;
 
     return {
 
@@ -27,7 +27,7 @@ export default function(volume) {
                 "in-use"
             ];
 
-            return validStates.indexOf(status_raw) >= 0;
+            return validStates.indexOf(status) >= 0;
         },
 
         isDeployError: function() {


### PR DESCRIPTION
This PR adds support for the following volume actions:

* Attach
* Detach

It also adds a dialog for each action, accessible from the "Actions" section of the menu on the volume card.

> Note: This is not a "final" implementation, and the UI is expected to change. This PR is about getting the functionality in place.

# Visual Illustrations
The screenshot below shows the menu for a detached volume, with actions enabled/disabled based on the status of the volume (`available` or `in-use`).

<img width="1033" alt="volume-menu" src="https://user-images.githubusercontent.com/2637399/34193911-653e0836-e513-11e7-8985-34fa350f648d.png">

The collection of screenshots below illustrates the experience for each included dialog.

<img width="1022" alt="volume-attach" src="https://user-images.githubusercontent.com/2637399/34193914-67c268d6-e513-11e7-8051-471c0dbcf790.png">

<img width="1024" alt="volume-detach" src="https://user-images.githubusercontent.com/2637399/34193891-490ba2e0-e513-11e7-9c0f-83517b44e62c.png">

# Key Callouts
Here are some things worth highlighting.

## Hidden usage of V1 API via custom `get` action for Volume
In some ways, volume actions are actually more difficult than instance actions, due to the fact that the `v2/volumes` endpoint doesn't return a `status` property on the volume. This means most questions in the application require two resources to answer them; the volume resource from `v2/volumes/:id` and the volume resource from `v1/provider/:uuid/identity/:uuid/volume/:uuid`.

Originally I tried to juggle them similarly to the way the status of an instance is juggled for instances as part of #15. But it required too many components to know the different between `volume` (v2 resource) and `volumeV1` (v1 resource).

To eliminate this need, I overrode the `get` action for `volume` in `src/actions/volume/get` and configured it to make *two* API calls instead of one. Basically, I made the decision to only use *one* volume resource in the application, but merge some of the data from the v1 API into that resource.

So the `get` actions for a volume makes an API call to `v2/volumes/:id`, and once it's done, but *before* the reducer store is updated, it makes a second API call to `v1/provider/:uuid/identity/:uuid/volume/:uuid`. It then takes the `attach_data` and `state` result from that API response, merges it into the `volume` resource, and *then* notifies the reducer store the `volume` request is `RESOLVED`.

## Debating using same approach for instances
Only needing to interact with a single Volume greatly lowers the cognitive overhead of interacting with data in the application. Now, when I fetch a volume, I know it will have everything I need on it, and I don't have to worry about the order pages are loaded, or when actions fire, or whether a secondary volume exists or not. I either have the volume (and it has all fields on it) or I don't.

## Polling Component
Similar to the component that polls instance status from #15, volumes has one for checking if a volume is in transition and polling until it reaches completion.

What's important to call out here is that the _action_ that component uses is *not* `lore.actions.volume.get` but `lore.actions.volume.updateV1`. While you *could* use the `get` action (and would for a typical API resource you needed to poll) in this specific scenario we need to remember the `get` action makes *two* API calls, and we only want to *update* the volume with information from the v1 endpoint.

So to avoid making unnecessary API calls, I created an `updateV1` action in `src/actions/volume/updateV1` that takes a `volume` resource and updates it with data from the v1 API.

## Parse method for volumeV1 model controls appended data for volume
If you look at the `parse` method for the `volumeV1` model it looks like this:

```jsx
parse: function(resp, options) {
    resp.state = {
        status_raw: resp.status,
        status: resp.status.split(" - ")[0],
        activity: resp.status.split(" - ")[1] || ''
    };
    return _.pick(resp, [
        'attach_data',
        'state'
    ]);
},
```

I'm intentionally stripping out ALL fields *except* `attach_data` and `state`, because those are the only fields I expect to ever see on a volume as of this PR. I'm basically using this method as a way to control what gets appended, and then appending everything that on this model (after parse is executed) onto the `volume`.

Without using this method as a way to control which fields are added, you have to update every action that merges v1 data onto the v2 volume (which at this point is `actions/volume/get` and `actions/volume/updateV1`).

With this method, you can simply include another field from the v1 API, and it will always show up in every volume automatically.