### PR TITLE
Modify Webpack Config to Support Remote SSL Development with Basename

### DIFF
--- a/config/router.js
+++ b/config/router.js
@@ -2,7 +2,8 @@
  * This file is where you define overrides for the default routing behavior.
  **/
 
-// import { browserHistory } from 'react-router';
+import { useRouterHistory } from 'react-router';
+import { createHistory } from 'history';
 
 export default {
 
@@ -11,7 +12,9 @@ export default {
      * See: https://github.com/reactjs/react-router/blob/master/docs/guides/Histories.md
      **/
 
-    // history: browserHistory,
+    history: useRouterHistory(createHistory)({
+        basename: __BASENAME__
+    }),
 
     /**
      * Returns the routes used by the application.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "build:production": "npm run clean && webpack --env.webpack=production --env.lore=production -p",
         "clean": "rimraf dist",
         "server": "json-server --watch db.json --port=1337",
-        "start": "webpack-dev-server --history-api-fallback --hot --env=development",
+        "start": "webpack-dev-server --hot --env.webpack=development --env.lore=development",
         "test": "echo \"Error: no test specified\" && exit 1",
         "stats": "npm run stats:development",
         "stats:development": "webpack --json --env=development > stats.json",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,9 +19,11 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var { getIfUtils, removeEmpty } = require('webpack-config-utils');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var FaviconsWebpackPlugin = require('favicons-webpack-plugin');
+var fs = require('fs');
 
 module.exports = function (env) {
     var { ifProduction, ifNotProduction } = getIfUtils(env.webpack || env);
+    var BASENAME = env.basename || '';
 
     return {
         devtool: ifProduction('source-map', 'eval'),
@@ -40,7 +42,7 @@ module.exports = function (env) {
             ),
             path: path.resolve('dist'),
             pathinfo: ifNotProduction(),
-            publicPath: '/'
+            publicPath: `${BASENAME}/`
         },
         resolve: {
             alias: {
@@ -167,6 +169,7 @@ module.exports = function (env) {
         plugins: removeEmpty([
             new webpack.DefinePlugin({
                 __LORE_ROOT__: JSON.stringify(__dirname),
+                __BASENAME__: JSON.stringify(BASENAME),
                 'process.env': {
                     'NODE_ENV': JSON.stringify(env.lore || env)
                 }
@@ -191,6 +194,7 @@ module.exports = function (env) {
             new HtmlWebpackPlugin({
                 template: './index.html',
                 inject: 'body',
+                publicPath: `${BASENAME}/`
             }),
             new FaviconsWebpackPlugin({
                 logo: './assets/images/favicon.png',
@@ -210,7 +214,14 @@ module.exports = function (env) {
             })
         ]),
         devServer: {
-            port: 3000
+            https: env.https || false,
+            host: env.host || 'localhost',
+            port: env.port || 3000,
+            key: env.key ? fs.readFileSync(env.key) : '',
+            cert: env.cert ? fs.readFileSync(env.cert) : '',
+            historyApiFallback: {
+                index: `${BASENAME}/index.html`,
+            }
         }
     };
 };


### PR DESCRIPTION
This PR modifies the webpack config to:

1. Support developing on a remote server with ssl support
2. Support hosting the app at a basename, like `/kaizen/`

# Key Callouts
Here are some things worth highlighting.

## Remove Server Development with SSL
The default command to run the webpack server is `npm start`, which boots up the webpack dev server on `http://localhost:3000`. This works fine when developing on a laptop via localhost, but doesn't support the development flow of operating on a remote machine, such as `https://server.cyverse.org`.

To support a remote ssl flow, instead of running `npm start`, you can now do this:

```sh
npm start --
  --env.https
  --env.host=server.cyverse.org
  --env.port=3000
  --env.sslKey=/path/to/ssl/server.cyverse.org.key 
  --env.sslCert=/path/to/ssl/server.cyverse.org.crt
```

This will boot the webpack development server on `https://server.example.org:3000` with the proper SSL certificates.

## Using a Basename
The default development flow assumes the app is running locally on `localhost:3000`. If you're development on a remote server behind nginx, you need need to host the app behind base route, like `https://server.cyverse.org/kaizen/`.

To do that, you can now pass a `basename` environment variable, like this:

```sh
npm start --
  --env.basename=/kaizen
```

This will do 4 things:

1.Tell webpack to server public assets behind `/kaizen/`
2. Tell the `html-webpack-plugin` to host the `index.html` file at `/kaizen/index.html`
3. Tell the weback-dev-server to use the file at `/kaizen/index.html` as the fallback for 404s (required for routing to work on page refresh)
4. Tell `react-router` to prepend all routes with `/kaizen/`