### PR TITLE
Redirect User on Login to Previous URL

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -11,8 +11,10 @@ export default createReactClass({
             clientId,
             redirectUri
         } = lore.config.cas;
+        const { location } = this.props;
+        const state = JSON.stringify(location.query);
 
-        window.location.href = `${serverUrl}?client_id=${clientId}&redirect_uri=${redirectUri}`;
+        window.location.href = `${serverUrl}?client_id=${clientId}&redirect_uri=${redirectUri}&state=${state}`;
     },
 
     render: function () {

--- a/src/components/_common/Header/Link.js
+++ b/src/components/_common/Header/Link.js
@@ -10,7 +10,10 @@ export default withRouter(createReactClass({
 
     propTypes: {
         label: PropTypes.string.isRequired,
-        to: PropTypes.string.isRequired,
+        to: PropTypes.oneOfType([
+            PropTypes.string.isRequired,
+            PropTypes.object.isRequired
+        ]).isRequired,
         matches: PropTypes.array.isRequired,
         icon: PropTypes.node,
     },

--- a/src/components/_common/Header/index.js
+++ b/src/components/_common/Header/index.js
@@ -86,6 +86,7 @@ export default withRouter(createReactClass({
     },
 
     render: function () {
+        const { location } = this.props;
         const { user } = this.context;
         const styles = this.getStyles();
 
@@ -116,7 +117,15 @@ export default withRouter(createReactClass({
                                 </DropDownMenu>
                             </IsAuthenticated>
                             <IsPublic>
-                                <HeaderLink label="Login" to="/login" matches={[/^\/login\//]}/>
+                                <HeaderLink label="Login" to={{
+                                    pathname: '/login',
+                                    query: {
+                                        redirect: JSON.stringify({
+                                            pathname: location.pathname,
+                                            query: location.query
+                                        })
+                                    }
+                                }} matches={[/^\/login\//]}/>
                             </IsPublic>
                         </ToolbarGroup>
                     </Toolbar>

--- a/src/components/auth-oauth/Layout.js
+++ b/src/components/auth-oauth/Layout.js
@@ -21,12 +21,18 @@ export default createReactClass({
             router
         } = this.props;
 
+        const state = query.state ? JSON.parse(query.state) : {
+            redirect: JSON.stringify({
+                pathname: '/'
+            })
+        };
+
         const accessTokenUrl = `${lore.config.cas.webtaskUrl}?code=${query.code}`;
 
         axios.get(accessTokenUrl).then(function (response) {
             const access_token = response.data.body.split('=')[1];
             auth.login(access_token);
-            router.push('/');
+            router.push(JSON.parse(state.redirect));
         }).catch(function (response) {
             const error = response.data;
 


### PR DESCRIPTION
This PR sets up the app so that if the user is logged out, and on the `/images/featured` page, if they click "Login", they'll be redirect to that page after login. Previously they were dumped on the homepage, and forced to navigate back.

## Problem
The challenge in addressing this is knowing how OAuth deals with "redirects", which it doesn't formally support. Meaning, when you create an OAuth service, you supply a `redirect_uri` like `http://localhost:3000`. But that URI has to be an _exact_ match when providing it to the OAuth service, like this:

```
https://hana.iplantcollaborative.org/cas/oauth2.0/authorize?client_id=localhost_serverless&redirect_uri=http://localhost:3000/auth/oauth
```

If you try to modify the `redirect_uri` to include query parameters, like `redirect_uri=http://localhost:3000/auth/oauth?redirect=/images/featured`

The OAuth service (CAS in our case) will block the login attempt because that's not _exactly_ the URL you specified (the _exact_ url we registered was `http://localhost:3000`).

## Solution
To support this use case, there is a `state` query parameter design into OAuth2 that you can pass to OAuth services, and they will pass it back to you, exactly as you wrote it. It it a bucket for "whatever you want".

So if you try to login on localhost with this URL (that includes a stringified JSON blob of data as the `state` query parameter):

https://hana.iplantcollaborative.org/cas/oauth2.0/authorize?client_id=mickey_kaizen_serverless&redirect_uri=https://mickey.cyverse.org/kaizen/auth/oauth&state="{"redirect":"/images/featured"}"

It will pass `state` back along to your application along with the `code` variable (that we exchange for a TGT token). And then you can pluck the `state` query parameter from the URL and parse it back into a JSON object and extract the `redirect` parameter (if one exists) and then redirect the user to that location.

Which is what I did in this PR.