### PR TITLE
Add create volume dialog

### DIFF
--- a/cyverse-ui-next/BarGraph.js
+++ b/cyverse-ui-next/BarGraph.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { createStyleSheet } from 'jss-theme-reactor';
+import muiThemeable from 'material-ui/styles/muiThemeable';
+import * as colors from 'material-ui/styles/colors';
+import { Element } from 'cyverse-ui';
+import getStyleManager from 'cyverse-ui/es/styles/getStyleManager';
+
+// Define static styles here.
+// Each key of the returned object will be available as a className below.
+const styleSheet = theme =>
+    createStyleSheet('BarGraph', theme => ({
+        wrapper: {
+            display: 'flex',
+            // background: colors.grey100,
+            background: '#D8D8D8'
+        },
+        barBefore: {
+            transition: 'flex-basis ease .3s',
+            flexShrink: '0',
+            maxWidth: '100%'
+        },
+        barAfter: {
+            transition: 'flex-basis ease .3s',
+            opacity: '.5'
+        }
+    }));
+/**
+ * BarGraph is used to show a percentage of a whole.
+ */
+const BarGraph = (props) => {
+    const {
+        startValue,
+        afterValue,
+        barColor,
+        compact,
+        muiTheme
+    } = props;
+
+    // Generate classes object and render corresponding style definitions in header.
+    const classes = getStyleManager(muiTheme).render(styleSheet());
+
+    const style = {
+        wrapper: {
+            height: compact ? '5px' : '10px'
+        },
+        barBefore: {
+            flexBasis: startValue + '%',
+            background: barColor
+        },
+        barAfter: {
+            flexBasis: afterValue + '%',
+            background: barColor
+        }
+    };
+
+    return (
+        <Element
+            display="flex"
+            style={style.wrapper}
+            className={classes.wrapper}
+        >
+            <div
+                style={style.barBefore}
+                className={classes.barBefore}
+            />
+            <div
+                style={style.barAfter}
+                className={classes.barAfter}
+            />
+        </Element>
+    );
+};
+BarGraph.displayName = 'BarGraph';
+
+BarGraph.propTypes = {
+    /**
+     * The number representing the primary percentage of a whole used
+     */
+    startValue: PropTypes.number,
+    /**
+     * The number representing the secondary percentage of a whole used. Typically a projected value after an action is taken.
+     */
+    afterValue: PropTypes.number,
+    /**
+     * The color of the bar representing the percentage of the whole used. The after value will be a lighter version of this color.
+     */
+    barColor: PropTypes.string,
+    /**
+     * Wether the BarGraph is compact or regular size
+     */
+    compact: PropTypes.bool,
+};
+
+export default muiThemeable()(BarGraph);

--- a/cyverse-ui-next/index.js
+++ b/cyverse-ui-next/index.js
@@ -1,3 +1,4 @@
+export { default as BarGraph } from './BarGraph';
 export { default as FloatingActionButton } from './FloatingActionButton';
 export { default as FloatingActionButtonAction } from './FloatingActionButtonAction';
 export { default as FloatingActionButtonActions } from './FloatingActionButtonActions';

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "axios": "~0.12.0",
         "babel-polyfill": "^6.23.0",
+        "bluebird": "^3.0.0",
         "bootstrap": "^4.0.0-beta.2",
         "color-hash": "^1.0.3",
         "create-react-class": "^15.6.2",

--- a/src/actions/volume/create.js
+++ b/src/actions/volume/create.js
@@ -1,0 +1,50 @@
+import { ActionTypes, PayloadStates, payload, normalize } from 'lore-utils';
+import getV1 from '../volumeV1/get';
+
+/*
+ * Blueprint for Create method
+ */
+export default function create(params) {
+    return function (dispatch) {
+        const Model = lore.models.volume;
+        const model = new Model(params);
+
+        model.save().then(function () {
+            // fetch the volume data from the v1 endpoint - we're going to extend
+            // our volume model with data we commonly need across the application
+            getV1(model.attributes)(function (action) {
+                const volumeV1 = action.payload;
+                if (volumeV1.state === PayloadStates.RESOLVED) {
+
+                    // look through the model and generate actions for any attributes with
+                    // nested data that should be normalized
+                    const actions = normalize(lore, 'volume').model(model);
+
+                    // modify volume with data from volumeV1 we want to extend it with
+                    _.extend(model.attributes, volumeV1.data);
+
+                    // dispatch the modified volume
+                    dispatch({
+                        type: ActionTypes.update('volume'),
+                        payload: payload(model, PayloadStates.RESOLVED)
+                    });
+
+                    // dispatch any actions created from normalizing nested data
+                    actions.forEach(dispatch);
+                }
+            });
+        }).catch(function (response) {
+            const error = response.data;
+
+            dispatch({
+                type: ActionTypes.remove('volume'),
+                payload: payload(model, PayloadStates.ERROR_CREATING, error)
+            });
+        });
+
+        return dispatch({
+            type: ActionTypes.add('volume'),
+            payload: payload(model, PayloadStates.CREATING)
+        });
+    };
+};

--- a/src/actions/volume/find.js
+++ b/src/actions/volume/find.js
@@ -1,0 +1,66 @@
+import _ from 'lodash';
+import { ActionTypes, PayloadStates, payloadCollection, normalize } from 'lore-utils';
+import Promise from 'bluebird';
+import getV1 from '../volumeV1/get';
+
+/*
+ * Blueprint for Find method
+ */
+
+export default function find(query = {}, pagination) {
+  return function(dispatch) {
+    const Collection = lore.collections.volume;
+    const collection = new Collection();
+
+    const queryParameters = _.extend({}, query, pagination);
+
+    const combinedQuery = {
+      where: query,
+      pagination: pagination
+    };
+
+    collection.fetch({
+      data: queryParameters
+    }).then(function(){
+        return Promise.map(collection.models, function(model) {
+            return new Promise(function(resolve, reject) {
+                getV1(model.attributes)(function(action) {
+                    const volumeV1 = action.payload;
+                    if (volumeV1.state === PayloadStates.RESOLVED) {
+                        // modify volume with data from volumeV1 we want to extend it with
+                        _.extend(model.attributes, volumeV1.data);
+                        resolve(model);
+                    }
+                });
+            });
+        });
+    }).then(function() {
+      // look through all models in the collection and generate actions for any attributes
+      // with nested data that should be normalized
+      const actions = normalize(lore, 'volume').collection(collection);
+
+      dispatch({
+        type: ActionTypes.fetchPlural('volume'),
+        payload: payloadCollection(collection, PayloadStates.RESOLVED, null, combinedQuery),
+        query: combinedQuery
+      });
+
+      // dispatch any actions created from normalizing nested data
+      actions.forEach(dispatch);
+    }).catch(function(response) {
+      const error = response.data;
+
+      dispatch({
+        type: ActionTypes.fetchPlural('volume'),
+        payload: payloadCollection(collection, PayloadStates.ERROR_FETCHING, error, combinedQuery),
+        query: combinedQuery
+      });
+    });
+
+    return dispatch({
+      type: ActionTypes.fetchPlural('volume'),
+      payload: payloadCollection(collection, PayloadStates.FETCHING, null, combinedQuery),
+      query: combinedQuery
+    });
+  };
+};

--- a/src/components/project-instances/ProjectInstances.js
+++ b/src/components/project-instances/ProjectInstances.js
@@ -27,7 +27,7 @@ export default connect(function(getState, props) {
             },
             pagination: {
                 page: '1',
-                page_size: 10
+                page_size: 100
             }
         }, { forceFetchOnMount: true })
     };

--- a/src/components/project/FloatingActionButton.js
+++ b/src/components/project/FloatingActionButton.js
@@ -4,8 +4,10 @@ import createReactClass from 'create-react-class';
 import { withRouter } from 'react-router';
 import { FloatingActionButton, FloatingActionButtonActions, FloatingActionButtonAction } from 'cyverse-ui-next';
 import { DeviceStorage } from 'material-ui/svg-icons';
+import { VolumeIcon } from 'cyverse-ui/es/icons';
 import onClickOutside from 'react-onclickoutside';
 import ImageLaunchDialog from '../../dialogs/image/launch';
+import CreateVolumeDialog from '../../dialogs/volume/create';
 
 const styles = {
     button: {
@@ -65,6 +67,22 @@ export default withRouter(onClickOutside(createReactClass({
                             lore.dialog.show(() => {
                                 return (
                                     <ImageLaunchDialog
+                                        project={project}
+                                        router={router}
+                                    />
+                                );
+                            });
+                        }}
+                        backgroundColor={styles.backgroundColor}
+                    />
+                    <FloatingActionButtonAction
+                        tooltip="New Volume"
+                        icon={<VolumeIcon/>}
+                        onClick={() => {
+                            this.onClick();
+                            lore.dialog.show(() => {
+                                return (
+                                    <CreateVolumeDialog
                                         project={project}
                                         router={router}
                                     />

--- a/src/dialogs/volume/create/BasicSettings/SetDefaults.js
+++ b/src/dialogs/volume/create/BasicSettings/SetDefaults.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { CircularProgress } from 'material-ui';
+import { Connect } from 'lore-hook-connect';
+import PayloadStates from '../../../../constants/PayloadStates';
+
+export default createReactClass({
+    displayName: 'SetDefaults',
+
+    propTypes: {
+        data: PropTypes.object.isRequired,
+        onSetDefaults: PropTypes.func.isRequired
+    },
+
+    render: function() {
+        const {
+            data,
+            onSetDefaults
+        } = this.props;
+
+        return (
+            <div style={{ textAlign: 'center', marginTop: 72 }}>
+                <Connect callback={(getState, props) => {
+                    return {
+                        identity: data.identity ? getState('identity.byId', {
+                            id: data.identity
+                        }) : getState('identity.first')
+                    }
+                }}>
+                    {(props) => {
+                        const { identity } = props;
+
+                        if (identity.state === PayloadStates.FETCHING) {
+                            return (
+                                <CircularProgress />
+                            );
+                        }
+
+                        return (
+                            <Connect callback={(getState, props) => {
+                                const data = {
+                                    identity: identity.id
+                                };
+                                onSetDefaults(data);
+                                return {};
+                            }}>
+                                <CircularProgress />
+                            </Connect>
+                        );
+                    }}
+                </Connect>
+            </div>
+        );
+    }
+
+});

--- a/src/dialogs/volume/create/BasicSettings/StorageUsageBar.js
+++ b/src/dialogs/volume/create/BasicSettings/StorageUsageBar.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { connect, Connect } from 'lore-hook-connect';
+import UsageBar from './UsageBar';
+import PayloadStates from '../../../../constants/PayloadStates';
+
+export default connect((getState, props) => {
+    const {
+        identity,
+        size
+    } = props.data;
+
+    return {
+        identity: identity ? getState('identity.byId', {
+            id: identity
+        }) : null,
+        size: size ? Number(size) : null
+    };
+})(
+createReactClass({
+    displayName: 'StorageUsageBar',
+
+    propTypes: {
+        identity: PropTypes.object,
+        size: PropTypes.number,
+    },
+
+    render: function() {
+        const {
+            identity,
+            size
+        } = this.props;
+
+        if (!identity || identity.state === PayloadStates.FETCHING) {
+            return (
+                <UsageBar
+                    title="Please select a provider to view the amount of available storage"
+                    startValue={0}
+                    afterValue={0}
+                />
+            );
+        }
+
+        if (!size) {
+            return (
+                <UsageBar
+                    title="Please specify a size to view the amount of available storage"
+                    startValue={0}
+                    afterValue={0}
+                />
+            );
+        }
+
+        return (
+            <Connect callback={(getState, props) => {
+                return {
+                    quota: getState('quota.byId', {
+                        id: identity.data.quota
+                    }),
+                    volumes: getState('volume.find', {
+                        where: {
+                            provider: identity.data.provider
+                        },
+                        exclude: {
+                            where: function(volume) {
+                                return volume.data.provider !== identity.data.provider;
+                            }
+                        }
+                    })
+                }
+            }}>
+                {(props) => {
+                    const {
+                        quota,
+                        volumes
+                    } = props;
+
+                    if (
+                        quota.state === PayloadStates.FETCHING ||
+                        volumes.state === PayloadStates.FETCHING
+                    ) {
+                        return (
+                            <UsageBar
+                                title="Calculating available storage..."
+                                startValue={0}
+                                afterValue={0}
+                            />
+                        );
+                    }
+
+                    const usedStorageSum = _.reduce(volumes.data, function(sum, volume) {
+                        return sum + volume.data.size;
+                    }, 0);
+
+                    const startPercent = usedStorageSum/quota.data.storage*100;
+                    const afterPercent = size/quota.data.storage*100;
+
+                    return (
+                        <UsageBar
+                            title={`Will use ${usedStorageSum + size} of ${quota.data.storage} allotted GBs of storage`}
+                            startValue={startPercent}
+                            afterValue={afterPercent}
+                            alertMessage={(
+                                <div>
+                                    <strong>Storage quota exceeded.</strong> Choose a smaller size or delete an existing volume.
+                                </div>
+                            )}
+                        />
+                    )
+                }}
+            </Connect>
+        );
+    }
+
+})
+);

--- a/src/dialogs/volume/create/BasicSettings/UsageBar.js
+++ b/src/dialogs/volume/create/BasicSettings/UsageBar.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { BarGraph } from 'cyverse-ui-next';
+
+export default createReactClass({
+    displayName: 'UsageBar',
+
+    propTypes: {
+        title: PropTypes.string.isRequired,
+        startValue: PropTypes.number.isRequired,
+        afterValue: PropTypes.number.isRequired,
+        alertMessage: PropTypes.node
+    },
+
+    render: function() {
+        const {
+            title,
+            startValue,
+            afterValue,
+            alertMessage
+        } = this.props;
+
+        const isOverLimit = (startValue + afterValue) > 100;
+        const color = isOverLimit ? '#F2453D' : 'rgba(0, 0, 0, 0.87)';
+        const barColor = isOverLimit ? '#F2453D' : '#5FB760';
+
+        return (
+            <div style={{ padding: 16 }}>
+                <div style={{ marginBottom: 8, color: color }}>
+                    {title}
+                </div>
+                <BarGraph
+                    startValue={startValue}
+                    afterValue={afterValue}
+                    barColor={barColor}
+                />
+                {alertMessage && (startValue + afterValue > 100) ? (
+                    <div style={{ marginTop: 8, fontSize: '15px', color: color }}>
+                        {alertMessage}
+                    </div>
+                ) :null}
+            </div>
+        );
+    }
+
+});

--- a/src/dialogs/volume/create/BasicSettings/VolumeUsageBar.js
+++ b/src/dialogs/volume/create/BasicSettings/VolumeUsageBar.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { connect, Connect } from 'lore-hook-connect';
+import UsageBar from './UsageBar';
+import PayloadStates from '../../../../constants/PayloadStates';
+
+export default connect((getState, props) => {
+    const {
+        identity,
+        size
+    } = props.data;
+
+    return {
+        identity: identity ? getState('identity.byId', {
+            id: identity
+        }) : null,
+        size: size ? Number(size) : null
+    };
+})(
+createReactClass({
+    displayName: 'VolumeUsageBar',
+
+    propTypes: {
+        identity: PropTypes.object,
+        size: PropTypes.number,
+    },
+
+    render: function() {
+        const {
+            identity,
+            size
+        } = this.props;
+
+        if (!identity || identity.state === PayloadStates.FETCHING) {
+            return (
+                <UsageBar
+                    title="Please select a provider to view the number of available volumes"
+                    startValue={0}
+                    afterValue={0}
+                />
+            );
+        }
+
+        return (
+            <Connect callback={(getState, props) => {
+                return {
+                    quota: getState('quota.byId', {
+                        id: identity.data.quota
+                    }),
+                    volumes: getState('volume.find', {
+                        where: {
+                            provider: identity.data.provider
+                        },
+                        exclude: {
+                            where: function(volume) {
+                                return volume.data.provider !== identity.data.provider;
+                            }
+                        }
+                    })
+                }
+            }}>
+                {(props) => {
+                    const {
+                        quota,
+                        volumes
+                    } = props;
+
+                    if (
+                        quota.state === PayloadStates.FETCHING ||
+                        volumes.state === PayloadStates.FETCHING
+                    ) {
+                        return (
+                            <UsageBar
+                                title="Calculating available volumes..."
+                                startValue={0}
+                                afterValue={0}
+                            />
+                        );
+                    }
+
+                    const startPercent = volumes.data.length/quota.data.storage_count*100;
+                    const afterPercent = 1/quota.data.storage_count*100;
+
+                    return (
+                        <UsageBar
+                            title={`Will use ${volumes.data.length + 1} of ${quota.data.storage_count} allotted volumes`}
+                            startValue={startPercent}
+                            afterValue={afterPercent}
+                            alertMessage={(
+                                <div>
+                                    <strong>Volume quota exceeded.</strong> You must delete an existing volume before creating a new one.
+                                </div>
+                            )}
+                        />
+                    )
+                }}
+            </Connect>
+        );
+    }
+
+})
+);

--- a/src/dialogs/volume/create/BasicSettings/index.js
+++ b/src/dialogs/volume/create/BasicSettings/index.js
@@ -1,0 +1,205 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import _ from 'lodash';
+import { CardTitle } from 'material-ui';
+import { Connect } from 'lore-hook-connect';
+import validators from '../../../../utils/validators';
+import GenericForm from '../../../_templates/_forms/GenericForm';
+import SchemaFields from '../../../_templates/_forms/SchemaFields';
+import CloseButton from '../../../_templates/_common/CloseButton';
+import RequestError from '../../../_templates/_common/RequestError';
+import BasicNavigation from '../_common/BasicNavigation';
+import SetDefaults from './SetDefaults';
+import VolumeUsageBar from './VolumeUsageBar';
+import StorageUsageBar from './StorageUsageBar';
+
+export default createReactClass({
+    displayName: 'BasicSettings',
+
+    propTypes: {
+        data: PropTypes.object,
+        validators: PropTypes.object,
+        onChange: PropTypes.func,
+        hasError: PropTypes.bool,
+        request: PropTypes.object,
+        callbacks: PropTypes.object,
+        schema: PropTypes.object.isRequired,
+        fieldMap: PropTypes.object.isRequired,
+        actionMap: PropTypes.object.isRequired,
+    },
+
+    getInitialState: function() {
+        const { data } = this.props;
+
+        return {
+            data: _.merge({}, data),
+            setDefaults: true
+        }
+    },
+
+    onChange: function(name, value) {
+        const nextState = _.merge({}, this.state);
+        nextState.data[name] = value;
+        this.setState(nextState);
+    },
+
+    onSetDefaults(defaults) {
+        const data = _.merge({}, this.state.data, defaults);
+        this.setState({
+            data: data,
+            setDefaults: false
+        });
+    },
+
+    render: function() {
+        const {
+            schema,
+            fieldMap,
+            actionMap,
+            callbacks,
+            hasError,
+            request
+        } = this.props;
+
+        const {
+            data,
+            setDefaults
+        } = this.state;
+
+        const config = {
+            validators: {
+                name: [validators.isRequired],
+                identity: [validators.number.isRequired],
+                size: [
+                    validators.isNumber,
+                    validators.number.minimum(1),
+                    validators.number.isRequired
+                ]
+            },
+            fields: {}
+        };
+
+        return (
+            <GenericForm
+                data={data}
+                onChange={this.onChange}
+                callbacks={callbacks}
+                schema={schema}
+                fieldMap={fieldMap}
+                actionMap={actionMap}
+                config={{
+                    validators: config.validators,
+                    fields: {},
+                    actions: []
+                }}
+            >
+                {(form) => (
+                    <div className="row" style={{ margin: 0, backgroundColor: '#f2f2f2', height: '100%' }}>
+                        <CloseButton onClick={callbacks.onCancel} />
+                        <div className="col" style={{ backgroundColor: 'white' }}>
+                            <BasicNavigation
+                                schema={schema}
+                                actionMap={actionMap}
+                                form={form}
+                                activeStep={2}
+                                helpText="Please review the default settings and modify as needed. Once the settings reflect what you want, click the 'Create Volume' button."
+                                nextButtonVisible={false}
+                                previousButtonVisible={true}
+                                otherButtonsVisible={true}
+                            />
+                        </div>
+                        {setDefaults ? (
+                            <div className="col-8">
+                                <SetDefaults
+                                    data={data}
+                                    onSetDefaults={this.onSetDefaults}
+                                />
+                            </div>
+                        ) : (
+                            <div className="col-8" style={{ overflow: 'scroll', height: '100%' }}>
+                                {hasError ? (
+                                    <div className="row">
+                                        <div className="col" style={{ padding: 0 }}>
+                                            <RequestError request={request}>
+                                                {(request) => {
+                                                    return request.error;
+                                                }}
+                                            </RequestError>
+                                        </div>
+                                    </div>
+                                ) : null}
+                                <div className="row">
+                                    <div className="col">
+                                        <CardTitle title="Basic Information" />
+                                        <SchemaFields
+                                            schema={schema}
+                                            fieldMap={fieldMap}
+                                            form={form}
+                                            fields={{
+                                                name: {
+                                                    type: 'string',
+                                                    props: {
+                                                        floatingLabelText: 'Volume Name'
+                                                    }
+                                                }
+                                            }}
+                                        />
+                                    </div>
+                                    <div className="col">
+                                        <CardTitle title="Volume Resources" />
+                                        <SchemaFields
+                                            schema={schema}
+                                            fieldMap={fieldMap}
+                                            form={form}
+                                            fields={{
+                                                identity: {
+                                                    type: 'select2',
+                                                    props: {
+                                                        floatingLabelText: 'Identity',
+                                                        label: (identity) => {
+                                                            return (
+                                                                <Connect callback={(getState, props) => {
+                                                                    return {
+                                                                        provider: getState('provider.byId', {
+                                                                            id: identity.data.provider
+                                                                        })
+                                                                    };
+                                                                }}>
+                                                                    {(props) => {
+                                                                        return props.provider.data.name;
+                                                                    }}
+                                                                </Connect>
+                                                            )
+                                                        },
+                                                        options: (getState, props) => {
+                                                            return getState('identity.find')
+                                                        }
+                                                    }
+                                                },
+                                                size: {
+                                                    type: 'string',
+                                                    props: {
+                                                        floatingLabelText: 'Volume Size (GB)'
+                                                    }
+                                                }
+                                            }}
+                                        />
+                                    </div>
+                                </div>
+                                <div className="row">
+                                    <div className="col">
+                                        <CardTitle title="Resource Consumption" />
+                                        <VolumeUsageBar data={data} />
+                                        <StorageUsageBar data={data} />
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                )}
+            </GenericForm>
+        );
+    }
+
+});

--- a/src/dialogs/volume/create/ConfirmationScreen/index.js
+++ b/src/dialogs/volume/create/ConfirmationScreen/index.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import _ from 'lodash';
+import { RaisedButton, FlatButton } from 'material-ui';
+import { NavigationCheck } from 'material-ui/svg-icons';
+import CloseButton from '../../../_templates/_common/CloseButton';
+import BasicNavigation from '../_common/BasicNavigation';
+import GenericForm from '../../../_templates/_forms/GenericForm';
+
+export default createReactClass({
+    displayName: 'ConfirmationScreen',
+
+    propTypes: {
+        data: PropTypes.object,
+        validators: PropTypes.object,
+        onChange: PropTypes.func,
+        request: PropTypes.object,
+        callbacks: PropTypes.object,
+        schema: PropTypes.object.isRequired,
+        fieldMap: PropTypes.object.isRequired,
+        actionMap: PropTypes.object.isRequired
+    },
+
+    getInitialState: function() {
+        const { data } = this.props;
+
+        return {
+            data: _.merge({}, data),
+            setDefaults: true
+        }
+    },
+
+    onChange: function(name, value) {
+        const nextState = _.merge({}, this.state);
+        nextState.data[name] = value;
+        this.setState(nextState);
+    },
+
+    onSetDefaults(defaults) {
+        const data = _.merge({}, this.state.data, defaults);
+        this.setState({
+            data: data,
+            setDefaults: false
+        });
+    },
+
+    render: function() {
+        const {
+            schema,
+            fieldMap,
+            actionMap,
+            callbacks
+        } = this.props;
+
+        const { data } = this.state;
+
+        return (
+            <GenericForm
+                data={data}
+                onChange={this.onChange}
+                callbacks={callbacks}
+                schema={schema}
+                fieldMap={fieldMap}
+                actionMap={actionMap}
+                config={{
+                    validators: {},
+                    fields: {},
+                    actions: []
+                }}
+            >
+                {(form) => (
+                    <div className="row" style={{ margin: 0, backgroundColor: '#f2f2f2', height: '100%' }}>
+                        <CloseButton onClick={callbacks.onCancel} />
+                        <div className="col" style={{ backgroundColor: 'white' }}>
+                            <BasicNavigation
+                                schema={schema}
+                                actionMap={actionMap}
+                                form={form}
+                                activeStep={3}
+                                helpText={(
+                                    <div>
+                                        <div>
+                                            Success, you are ready to do science.
+                                        </div>
+                                    </div>
+                                )}
+                            />
+                        </div>
+                        <div className="col-8">
+                            <div className="row">
+                                <div className="col" style={{ textAlign: 'center', marginTop: 72 }}>
+                                    <NavigationCheck
+                                        color="#359121"
+                                        style={{
+                                            height: 72,
+                                            width: 72
+                                        }}
+                                    />
+                                    <h1>
+                                        Volume has been created successfully!
+                                    </h1>
+                                    <div>
+                                        You may now attach it to an instance.
+                                    </div>
+                                    <div style={{ marginTop: 32 }}>
+                                        <RaisedButton
+                                            primary={false}
+                                            label="Continue to Volume"
+                                            onClick={() => {
+                                                form.callbacks.onNavigateToVolume()
+                                            }}
+                                        />
+                                    </div>
+                                    <div style={{ marginTop: 24 }}>
+                                        <FlatButton
+                                            primary={false}
+                                            label="Create Another Volume"
+                                            onClick={() => {
+                                                form.callbacks.onResetWizard()
+                                            }}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </GenericForm>
+        );
+    }
+
+});

--- a/src/dialogs/volume/create/SelectProject/SetDefaults.js
+++ b/src/dialogs/volume/create/SelectProject/SetDefaults.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import _ from 'lodash';
+import { CircularProgress } from 'material-ui';
+import { Connect } from 'lore-hook-connect';
+import PayloadStates from '../../../../constants/PayloadStates';
+
+export default createReactClass({
+    displayName: 'SetDefaults',
+
+    propTypes: {
+        data: PropTypes.object.isRequired,
+        onSetDefaults: PropTypes.func.isRequired
+    },
+
+    render: function() {
+        const {
+            data,
+            onSetDefaults
+        } = this.props;
+
+        return (
+            <div style={{ textAlign: 'center', marginTop: 72 }}>
+                <Connect callback={(getState, props) => {
+                    return {
+                        project: data.project ? getState('project.byId', {
+                            id: data.project
+                        }) : getState('project.first')
+                    }
+                }}>
+                    {(props) => {
+                        const { project } = props;
+
+                        if (project.state === PayloadStates.FETCHING) {
+                            return (
+                                <CircularProgress />
+                            );
+                        }
+
+                        return (
+                            <Connect callback={(getState, props) => {
+                                const data = {
+                                    project: project.id
+                                };
+                                onSetDefaults(data);
+                                return {};
+                            }}>
+                                <CircularProgress />
+                            </Connect>
+                        );
+                    }}
+                </Connect>
+            </div>
+        );
+    }
+
+});

--- a/src/dialogs/volume/create/SelectProject/index.js
+++ b/src/dialogs/volume/create/SelectProject/index.js
@@ -1,0 +1,136 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import _ from 'lodash';
+import { CardTitle } from 'material-ui';
+import CloseButton from '../../../_templates/_common/CloseButton';
+import BasicNavigation from '../_common/BasicNavigation';
+import GenericForm from '../../../_templates/_forms/GenericForm';
+import SchemaFields from '../../../_templates/_forms/SchemaFields';
+import validators from '../../../../utils/validators';
+import SetDefaults from './SetDefaults';
+
+export default createReactClass({
+    displayName: 'SelectProject',
+
+    propTypes: {
+        data: PropTypes.object,
+        validators: PropTypes.object,
+        onChange: PropTypes.func,
+        request: PropTypes.object,
+        callbacks: PropTypes.object,
+        schema: PropTypes.object.isRequired,
+        fieldMap: PropTypes.object.isRequired,
+        actionMap: PropTypes.object.isRequired
+    },
+
+    getInitialState: function() {
+        const { data } = this.props;
+
+        return {
+            data: _.merge({}, data),
+            setDefaults: true
+        }
+    },
+
+    onChange: function(name, value) {
+        const nextState = _.merge({}, this.state);
+        nextState.data[name] = value;
+        this.setState(nextState);
+    },
+
+    onSetDefaults(defaults) {
+        const data = _.merge({}, this.state.data, defaults);
+        this.setState({
+            data: data,
+            setDefaults: false
+        });
+    },
+
+    render: function() {
+        const {
+            schema,
+            fieldMap,
+            actionMap,
+            callbacks
+        } = this.props;
+
+        const {
+            data,
+            setDefaults
+        } = this.state;
+
+        const config = {
+            validators: {
+                project: [validators.number.isRequired]
+            },
+            fields: {
+                project: {
+                    type: 'select',
+                    props: {
+                        floatingLabelText: 'Project',
+                        field: 'name',
+                        options: (getState, props) => {
+                            return getState('project.find')
+                        }
+                    }
+                }
+            }
+        };
+
+        return (
+            <GenericForm
+                data={data}
+                onChange={this.onChange}
+                callbacks={callbacks}
+                schema={schema}
+                fieldMap={fieldMap}
+                actionMap={actionMap}
+                config={{
+                    validators: config.validators,
+                    fields: {},
+                    actions: []
+                }}
+            >
+                {(form) => (
+                    <div className="row" style={{ margin: 0, backgroundColor: '#f2f2f2', height: '100%' }}>
+                        <CloseButton onClick={callbacks.onCancel} />
+                        <div className="col" style={{ backgroundColor: 'white' }}>
+                            <BasicNavigation
+                                schema={schema}
+                                actionMap={actionMap}
+                                form={form}
+                                activeStep={0}
+                                helpText="Which project would you like to add the volume to?"
+                                nextButtonVisible={true}
+                            />
+                        </div>
+                        {setDefaults ? (
+                            <div className="col-8">
+                                <SetDefaults
+                                    data={data}
+                                    onSetDefaults={this.onSetDefaults}
+                                />
+                            </div>
+                        ) : (
+                            <div className="col-8">
+                                <div className="row">
+                                    <div className="col">
+                                        <CardTitle title="Project Selection" />
+                                        <SchemaFields
+                                            schema={schema}
+                                            fieldMap={fieldMap}
+                                            form={form}
+                                            fields={_.pick(config.fields, ['project'])}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                )}
+            </GenericForm>
+        );
+    }
+
+});

--- a/src/dialogs/volume/create/_common/BasicNavigation.js
+++ b/src/dialogs/volume/create/_common/BasicNavigation.js
@@ -1,0 +1,140 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import _ from 'lodash';
+import { CardTitle, Stepper, Step, StepLabel, StepContent } from 'material-ui';
+import { NavigationArrowForward, NavigationArrowBack } from 'material-ui/svg-icons';
+import SchemaActions from '../../../_templates/_forms/SchemaActions';
+import InfoMessage from '../../../_templates/_common/InfoMessage';
+
+export default createReactClass({
+    displayName: 'BasicNavigation',
+
+    propTypes: {
+        schema: PropTypes.object.isRequired,
+        actionMap: PropTypes.object.isRequired,
+        form: PropTypes.object.isRequired,
+        activeStep: PropTypes.number.isRequired,
+        title: PropTypes.string,
+        subtitle: PropTypes.string,
+        helpText: PropTypes.node,
+        previousButtonVisible: PropTypes.bool,
+        nextButtonVisible: PropTypes.bool,
+        otherButtonsVisible: PropTypes.bool,
+    },
+
+    getDefaultProps() {
+        return {
+            previousButtonVisible: false,
+            nextButtonVisible: false,
+            otherButtonsVisible: false
+        };
+    },
+
+    render: function() {
+        const {
+            schema,
+            actionMap,
+            form,
+            activeStep,
+            title,
+            subtitle,
+            helpText,
+            previousButtonVisible,
+            nextButtonVisible,
+            otherButtonsVisible
+        } = this.props;
+
+        return (
+            <div>
+                <CardTitle
+                    title={title || 'Create Volume Wizard'}
+                    subtitle={subtitle}
+                />
+                <Stepper activeStep={activeStep} orientation="vertical" style={{ marginBottom: '16px' }}>
+                    {[
+                        'Project Select',
+                        'Basic Info',
+                    ].map((step, index) => {
+                        return (
+                            <Step key={index}>
+                                <StepLabel>
+                                    {step}
+                                </StepLabel>
+                                <StepContent/>
+                            </Step>
+                        );
+                    })}
+                </Stepper>
+                {helpText ? (
+                    <InfoMessage>
+                        {helpText}
+                    </InfoMessage>
+                ) : null}
+                <div className="clearfix" style={{ minHeight: 52 }}>
+                <SchemaActions
+                    schema={schema}
+                    actionMap={actionMap}
+                    form={form}
+                    actions={_.flatten([
+                        previousButtonVisible ? {
+                            type: 'flat',
+                            props: {
+                                label: 'Back',
+                                icon: <NavigationArrowBack />,
+                                primary: true,
+                                style: {
+                                    float: 'left'
+                                },
+                                onClick: () => {
+                                    form.callbacks.onPrevious(form.data)
+                                }
+                            }
+                        } : [],
+                        nextButtonVisible ? {
+                            type: 'flat',
+                            props: {
+                                label: 'Next',
+                                labelPosition: 'before',
+                                icon: <NavigationArrowForward />,
+                                primary: true,
+                                disabled: form.hasError,
+                                onClick: () => {
+                                    form.callbacks.onNext(form.data)
+                                }
+                            }
+                        } : [],
+                    ])}
+                />
+                </div>
+                {otherButtonsVisible ? (
+                    <div>
+                    <SchemaActions
+                        schema={schema}
+                        actionMap={actionMap}
+                        form={form}
+                        actions={[
+                            {
+                                type: 'raised',
+                                props: {
+                                    label: 'Create Volume',
+                                    primary: true,
+                                    disabled: form.hasError,
+                                    style: {
+                                        display: 'block',
+                                        width: '100%'
+                                    },
+                                    onClick: () => {
+                                        form.callbacks.onSubmit(form.data)
+                                    }
+                                }
+                            }
+                        ]}
+                    />
+                    </div>
+                ) : null}
+            </div>
+        );
+    }
+
+});

--- a/src/dialogs/volume/create/_common/Steps.js
+++ b/src/dialogs/volume/create/_common/Steps.js
@@ -1,0 +1,5 @@
+export default {
+    SELECT_PROJECT: 0,
+    BASIC_SETTINGS: 1,
+    CONFIRMATION: 2
+};

--- a/src/dialogs/volume/create/index.js
+++ b/src/dialogs/volume/create/index.js
@@ -1,0 +1,241 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import { getState } from 'lore-hook-connect';
+import FullScreenDialog from '../../../../src/decorators/FullScreenDialog';
+import Overlay from '../../_templates/_common/Overlay';
+import Request from '../../_templates/_common/Request';
+import SelectProject from './SelectProject';
+import BasicSettings from './BasicSettings';
+import ConfirmationScreen from './ConfirmationScreen';
+import Steps from './_common/Steps';
+
+export default FullScreenDialog()(createReactClass({
+    displayName: 'Volume/Create',
+
+    propTypes: {
+        project: PropTypes.object,
+        image: PropTypes.object,
+        router: PropTypes.object.isRequired,
+        onCancel: PropTypes.func.isRequired
+    },
+
+    request: function(data) {
+        const project = getState('project.byId', { id: data.project });
+        const identity = getState('identity.byId', { id: data.identity });
+
+        return lore.actions.volume.create({
+            project: project.data.uuid,
+            name: data.name,
+            identity: identity.data.uuid,
+            size: Number(data.size)
+        }).payload;
+    },
+
+    getInitialState() {
+        const {
+            project,
+            image,
+            data
+        } = this.props;
+
+        function getInitialStepIndex() {
+            if (!project) {
+                return Steps.SELECT_PROJECT;
+            }
+
+            return Steps.BASIC_SETTINGS;
+        }
+
+        return {
+            stepIndex: getInitialStepIndex(),
+            data: _.extend({}, {
+                project: project ? project.id : undefined,
+                name: '',
+                identity: undefined,
+                size: 1
+            }, data),
+            isSaving: false,
+            request: null,
+            hasError: false
+        }
+    },
+
+    onSubmit: function(newData) {
+        const { data } = this.state;
+        const nextData = _.extend({}, data, newData);
+
+        this.setState({
+            isSaving: true,
+            hasError: false,
+            data: nextData,
+            request: this.request(nextData, this)
+        });
+    },
+
+    onRequestSuccess: function(request) {
+        this.setState({
+            isSaving: false,
+            request: request,
+            hasError: false,
+            stepIndex: Steps.CONFIRMATION
+        });
+    },
+
+    onRequestError: function(request) {
+        this.setState({
+            isSaving: false,
+            request: request,
+            hasError: true
+        });
+    },
+
+    onResetWizard: function() {
+        this.setState(_.extend(this.getInitialState(), {
+            stepIndex: 0
+        }));
+    },
+
+    onNavigateToVolume() {
+        const {
+            router,
+            onCancel
+        } = this.props;
+        const { data } = this.state;
+
+        router.push(`/projects/${data.project}/volumes`);
+        onCancel();
+    },
+
+    onNext: function(newData, newStepIndex) {
+        const {
+            data,
+            stepIndex
+        } = this.state;
+
+        this.setState({
+            stepIndex: newStepIndex || (stepIndex + 1),
+            data: _.extend({}, data, newData)
+        });
+    },
+
+    onPrevious: function(newData, newStepIndex) {
+        const {
+            data,
+            stepIndex
+        } = this.state;
+
+        this.setState({
+            stepIndex: newStepIndex || (stepIndex - 1),
+            data: _.extend({}, data, newData)
+        });
+    },
+
+    onChangeStep(newData, newStepIndex) {
+        const { data } = this.state;
+
+        this.setState({
+            stepIndex: newStepIndex,
+            data: _.extend({}, data, newData)
+        });
+    },
+
+    render: function() {
+        const {
+            onSubmit,
+            onCancel
+        } = this.props;
+
+        const {
+            data,
+            stepIndex,
+            request,
+            isSaving,
+            hasError
+        } = this.state;
+
+        const {
+            schemas,
+            fieldMap,
+            actionMap
+        } = lore.config.dialogs;
+
+        const steps = [
+            {
+                form: 'custom',
+                render: (props) => {
+                    return (
+                        <SelectProject
+                            {...props}
+                            callbacks={{
+                                onNext: (newData) => {
+                                    this.onNext(newData, Steps.BASIC_SETTINGS)
+                                },
+                                onCancel: onCancel
+                            }}
+                        />
+                    );
+                }
+            },
+            {
+                form: 'custom',
+                render: (props) => {
+                    return (
+                        <BasicSettings
+                            {...props}
+                            hasError={hasError}
+                            request={request}
+                            callbacks={{
+                                onPrevious: (newData) => {
+                                    this.onPrevious(newData, Steps.SELECT_PROJECT)
+                                },
+                                onSubmit: this.onSubmit,
+                                onCancel: onCancel
+                            }}
+                        />
+                    );
+                }
+            },
+            {
+                form: 'custom',
+                render: (props) => {
+                    return (
+                        <ConfirmationScreen
+                            {...props}
+                            callbacks={{
+                                onResetWizard: this.onResetWizard,
+                                onNavigateToVolume: this.onNavigateToVolume,
+                                onCancel: onCancel
+                            }}
+                        />
+                    );
+                }
+            }
+        ];
+
+        const step = steps[stepIndex].render({
+            data: data,
+            schema: schemas.default,
+            fieldMap: fieldMap,
+            actionMap: actionMap
+        });
+
+        return (
+            <Overlay isVisible={isSaving}>
+                <div>
+                    {(request && isSaving) ? (
+                        <Request
+                            request={request}
+                            reducer="volume"
+                            onSuccess={this.onRequestSuccess}
+                            onError={this.onRequestError}
+                        />
+                    ) : null}
+                    {step}
+                </div>
+            </Overlay>
+        );
+    }
+
+}));

--- a/src/models/volume.js
+++ b/src/models/volume.js
@@ -65,6 +65,10 @@ export default {
         parse: function (resp, options) {
             resp.provider_uuid = resp.provider.uuid;
             resp.identity_uuid = resp.identity.uuid;
+
+            if (_.isPlainObject(resp.project)) {
+                resp.project = resp.project.id;
+            }
             return resp;
         },
 

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -6,8 +6,26 @@ function isRequired(value) {
     }
 }
 
+function isNumber(value) {
+    if (value === null || value === undefined) {
+        return;
+    }
+
+    if (!validator.isInt(String(value), { allow_leading_zeroes: false })) {
+        return 'Must be a number'
+    }
+}
+
+function isNumberAndGreaterThan(min) {
+    return function(value) {
+        if (!isNumber(value) && !validator.isInt(String(value), { min: min })) {
+            return `Must be greater than ${min}`;
+        }
+    }
+}
+
 function isRequiredAndNumber(value) {
-    if (value === null || value === undefined || !validator.isNumeric(String(value))) {
+    if (value === null || value === undefined || isNumber(value)) {
         return 'This field is required'
     }
 }
@@ -40,7 +58,9 @@ export default {
     isRequired: isRequired,
     isEmail: isEmail,
     isUrl: isUrl,
+    isNumber: isNumber,
     number: {
+        minimum: isNumberAndGreaterThan,
         isRequired: isRequiredAndNumber,
     },
     boolean: {


### PR DESCRIPTION
This PR expands the Floating Action Button on a Project page with a "New Volume" button that allows the user to create a new volume, including:

* The ability to change the project
* The ability to set name, provider and size
* The ability to see current quota constraints on that provider

This PR *does not* include:

* The ability to prevent the user from submitting the from if the the volume will exceed their quota. That will be a future PR (the instances dialog has the same limitation). _However_ the dialog will detect the API error and display it to the user, so that flow at least has _a_ solution, even if it's not the one we want yet.

# Visual Demonstration
Here is a 7 MB GIF demonstrating the basic user flow (may need to give it a minute to load).

![create-volume-wizard](https://user-images.githubusercontent.com/2637399/35198465-877e6a14-feac-11e7-8b16-a59edcd5f671.gif)

# Key Callouts
Here are some things worth highlighting.

## Overrode volume/create and volume/find actions
In a previous PR, I updated the volume/get action to fetch the volume from the v2 endpoint, and also fetch the state from the v1 endpoint, and then merge them together (to create the true representation of the volume) before passing it to the application. This allowed any view that required a volume to be guaranteed it would get whatever fields it needed, without multiple components haven't to do checks like "get volume, and if state doesn't exist, got fetch it from the v1 endpoint, and throw up a spinner until it comes back".

However, this ends up effecting the `create` and `find` endpoints as well. The `create` action is effected because the application now expects `state` to exist on a volume, and it isn't returned from the v2 endpoint, so I modified `create` to go fetch it from the v1 endpoint before returning the created object.

The `find` action is being used to calculate quota usage for a provider, by retrieving the list of volumes on a specific provider. But again, this data doesn't include the `state` data, so I overrode the `find` action to fetch the `state` from the v1 endpoint for each volume returned in the list.

This now guarantees that any component that retrieves or creates a volume will always get the full (true) representation, and no components will need to juggle logic like "if state exists..."

The downside is this creates additional API calls : (

> Ultimately it seems like a trade-space "battle to crown the lesser evil", but this approach would give a clear deprecation path if we were able to move `state` data into the v2 endpoint, since we'd only need to modify (or delete) the custom actions, and the app itself could stay untouched.

## CyVerse UI: BarGraph
I copied the `BarGraph` from `cyverse-ui` into `cyverse-ui-next` so I could change the `backgroundColor` from grey100 (hard-coded value) to something else. Grey100 is the color of the dialog background, which prevented me from seeing the Bargraph's background.

## Page size for a Project Instance's and Volume's lists increased to 100
The project instances and volumes tabs were configured to be infinite scrolling lists with a page_size of 10. So if you had more instances than that, you could "load more" and see the next set.

In practice, the API doesn't support this flow, because if I "load volumes, create a volume, and then lore more volumes" there will be a duplicate volume on page 1 and page 2, and React will throw an warning about multiple list items having the same key, and the user will see duplicate volumes in their list.

In other to solve this, the API needs to support queries like "give me the first 10 volumes created before X date", and that will keep the data on the pages static. 

But since I can't ask that question, I went for the "easy route" and just bumped the `page_size` up to something absurdly high, to effectively disable pagination until/if the API supports that ability.

## Create Volume dialog copies the Image Launch Wizard
Originally I was going to model the create volume dialog after a smaller single-screen dialog (single step experience), but then I realized:

1. Are there an "advanced" dialog settings, or planned settings?
2. Is there an experience that requires the user to set a project, or change a project?
3. The image launch dialog already exists and is pretty robust, and accounts for answering both of the above questions

So I just made it a full screen dialog, and we can scale it down later if don't need the flexibility. That seemed preferable in the short term to designing a small custom dialog and then tearing it out later if questions 1 and 2 are something we need to account for.