### PR TITLE
Add ability to favorite images

### DIFF
--- a/blueprints/actions/destroy.js
+++ b/blueprints/actions/destroy.js
@@ -1,0 +1,48 @@
+import { ActionTypes, PayloadStates, normalize } from 'lore-utils';
+import destroy from '../lore-actions/destroy';
+
+export default function(modelName, models, lore) {
+    const Model = models[modelName];
+
+    return destroy({
+        blueprint: 'destroy',
+
+        model: Model,
+
+        optimistic: {
+            actionType: ActionTypes.update(modelName),
+            payloadState: PayloadStates.DELETING
+        },
+
+        onSuccess: {
+            actionType: ActionTypes.update(modelName),
+            payloadState: PayloadStates.DELETED
+        },
+
+        onError: {
+            actionType: ActionTypes.update(modelName),
+            payloadState: PayloadStates.ERROR_DELETING
+        },
+
+        onNotFound: {
+            actionType: ActionTypes.update(modelName),
+            payloadState: PayloadStates.NOT_FOUND
+        },
+
+        normalize: {
+
+            // look through the model and generate actions for any attributes with
+            // nested data that should be normalized
+            getActions: function(model) {
+                return normalize(lore, modelName).model(model);
+            },
+
+            // dispatch any actions created from normalizing nested data
+            dispatchActions: function(actions, dispatch) {
+                actions.forEach(dispatch);
+            }
+
+        }
+
+    });
+}

--- a/blueprints/lore-actions/destroy.js
+++ b/blueprints/lore-actions/destroy.js
@@ -1,0 +1,92 @@
+/* eslint consistent-return: "off" */
+
+import _ from 'lodash';
+import { utils } from 'lore-actions';
+const { defaultOptions, validatePartialPairs } = utils;
+
+/*
+ * Blueprint for Destroy method
+ */
+export default function(opts = {}) {
+    // clone the options so we don't unintentionally modify them
+    let options = _.cloneDeep(opts);
+
+    options = _.defaultsDeep(options, defaultOptions);
+
+    if (!options.model) {
+        throw new Error('Must specify a model');
+    }
+
+    const Model = options.model;
+
+    validatePartialPairs(options);
+
+    return function destroy(model) {
+        return function(dispatch) {
+            const proxyModel = new Model(model.data);
+
+            proxyModel.destroy().then(function() {
+                if (options.onSuccess) {
+                    let actions = [];
+
+                    if (options.normalize && options.normalize.getActions) {
+                        // look through the model and generate actions for any attributes with
+                        // nested data that should be normalized
+                        actions = options.normalize.getActions(proxyModel);
+                    }
+
+                    dispatch({
+                        type: options.onSuccess.actionType,
+                        payload: _.merge(model, {
+                            state: options.onSuccess.payloadState
+                        })
+                    });
+
+                    if (options.normalize && options.normalize.dispatchActions) {
+                        // dispatch any actions created from normalizing nested data
+                        options.normalize.dispatchActions(actions, dispatch);
+                    }
+                }
+            }).catch(function(response) {
+                const error = response.data;
+
+                if (response.status === 404) {
+                    if (options.onNotFound) {
+                        if (options.onNotFound.beforeDispatch) {
+                            options.onNotFound.beforeDispatch(response, [model]);
+                        }
+
+                        dispatch({
+                            type: options.onNotFound.actionType,
+                            payload: _.merge(model, {
+                                state: options.onNotFound.payloadState,
+                                error: error
+                            })
+                        });
+                    }
+                } else if (options.onError) {
+                    if (options.onError.beforeDispatch) {
+                        options.onError.beforeDispatch(response, [model]);
+                    }
+
+                    dispatch({
+                        type: options.onError.actionType,
+                        payload: _.merge(model, {
+                            state: options.onError.payloadState,
+                            error: error
+                        })
+                    });
+                }
+            });
+
+            if (options.optimistic) {
+                return dispatch({
+                    type: options.optimistic.actionType,
+                    payload: _.merge(model, {
+                        state: options.optimistic.payloadState
+                    })
+                });
+            }
+        };
+    };
+}

--- a/config/actions.js
+++ b/config/actions.js
@@ -3,6 +3,7 @@
  *
  * This file is where you define overrides for the default action behaviors.
  */
+import destroy from '../blueprints/actions/destroy';
 
 export default {
 
@@ -25,6 +26,10 @@ export default {
     //   get: function() {...},
     //   update: function() {...},
     // },
+
+    blueprints: {
+        destroy: destroy
+    },
 
     /**
      * Determines whether the client-side id (the cid attribute in a model)

--- a/src/components/images-search-favorites/ImageBookmarks.js
+++ b/src/components/images-search-favorites/ImageBookmarks.js
@@ -25,7 +25,9 @@ export default connect(function(getState, props) {
         }, { forceFetchOnMount: true })
     };
 })(
-InfiniteScrolling({ propName: 'imageBookmarks', modelName: 'imageBookmark' })(
+InfiniteScrolling({ propName: 'imageBookmarks', modelName: 'imageBookmark', exclude: function(imageBookmark) {
+    return imageBookmark.state === PayloadStates.DELETED;
+}})(
 createReactClass({
     displayName: 'ImageBookmarks',
 
@@ -68,7 +70,7 @@ createReactClass({
             }
 
             return _.flatten(imageBookmarks.data.map((imageBookmark, index) => {
-                const items = [(
+                return [(
                     <Connect key={imageBookmark.id || imageBookmark.cid} callback={(getState, props) => {
                         return {
                             image: getState('image.byId', {
@@ -95,25 +97,17 @@ createReactClass({
                         }}
                     </Connect>
                 )];
-
-                if (true || index < (imageBookmarks.data.length - 1)) {
-                    items.push(
-                        <Divider key={`divider-${imageBookmark.id || imageBookmark.cid}`}/>
-                    );
-                }
-
-                return items;
             }))
         }));
 
         let title = '';
 
         if (!firstPage.meta || !firstPage.meta.totalCount) {
-            title = `Showing ${imageListItems.length/2} images`;
+            title = `Showing ${imageListItems.length} images`;
         } else if (query.search) {
-            title = `Showing ${imageListItems.length/2} images for "${query.search}"`;
+            title = `Showing ${imageListItems.length} images for "${query.search}"`;
         } else {
-            title = `Showing ${imageListItems.length/2} of ${firstPage.meta.totalCount} images`;
+            title = `Showing ${imageListItems.length} of ${firstPage.meta.totalCount} images`;
         }
 
         return (
@@ -123,11 +117,9 @@ createReactClass({
                         {title}
                     </div>
                 </ListHeader>
-                <Paper>
-                    <List style={{ padding: '0px' }}>
-                        {imageListItems}
-                    </List>
-                </Paper>
+                <div>
+                    {imageListItems}
+                </div>
                 <LoadMoreButton
                     label="Show More Images"
                     lastPage={lastPage}

--- a/src/components/images-search/Tabs.js
+++ b/src/components/images-search/Tabs.js
@@ -7,6 +7,7 @@ import { Pill, ListTabs, ListTab } from 'cyverse-ui-next';
 import { connect } from 'lore-hook-connect';
 import PayloadStates from '../../constants/PayloadStates';
 import IsAuthenticated from '../_common/IsAuthenticated';
+import cacheUpdated from '../../utils/cacheUpdated';
 
 const ROUTES = {
     ALL: '/images/search/all',
@@ -50,7 +51,7 @@ export default withRouter(connect((getState, props) => {
                 page_size: 10,
                 image__search: location.query.search
             }
-        })
+        }, { force: cacheUpdated('imageBookmark') })
     }
 })(
 withRouter(createReactClass({

--- a/src/components/images-search/_common/Image/Bookmark.js
+++ b/src/components/images-search/_common/Image/Bookmark.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import { withRouter } from 'react-router';
+import PropTypes from 'prop-types';
+import { IconButton } from 'material-ui';
+import { ToggleStar, ToggleStarBorder } from 'material-ui/svg-icons';
+import { connect } from 'lore-hook-connect';
+import PayloadStates from '../../../../constants/PayloadStates';
+
+export default connect(function(getState, props) {
+    const { image } = props;
+
+    // todo: this should really be getState('imageBookmark.first', ...)
+    // but the API doesn't currently support filtering by image
+
+    // return {
+    //     imageBookmark: getState('imageBookmark.first', {
+    //         where: {
+    //             image_id: image.id
+    //         }
+    //     })
+    // };
+
+    return {
+        imageBookmarks: getState('imageBookmark.findAll', {
+            where: {
+                image: image.id
+            }
+        })
+    };
+})(
+withRouter(createReactClass({
+    displayName: 'Image',
+
+    propTypes: {
+        imageBookmarks: PropTypes.object.isRequired
+    },
+
+    getImageBookmark(props) {
+        const { image, imageBookmarks } = props;
+
+        if (imageBookmarks.state === PayloadStates.FETCHING) {
+            return {
+                state: PayloadStates.FETCHING
+            };
+        }
+
+        const imageBookmark = _.find(imageBookmarks.data, function(imageBookmark) {
+            return imageBookmark.data.image === image.id;
+        });
+
+        if (imageBookmark) {
+            return imageBookmark;
+        }
+
+        return {
+            state: PayloadStates.NOT_FOUND
+        };
+    },
+
+    getInitialState() {
+        return {
+            imageBookmark: this.getImageBookmark(this.props)
+        };
+    },
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({
+            imageBookmark: this.getImageBookmark(nextProps)
+        });
+    },
+
+    bookmarkImage() {
+        const { image } = this.props;
+        lore.actions.imageBookmark.create({
+            image: image.id
+        });
+    },
+
+    removeBookmark() {
+        const { imageBookmark } = this.state;
+        lore.actions.imageBookmark.destroy(imageBookmark);
+    },
+
+    render: function () {
+        const {
+            // imageBookmark,
+            image
+        } = this.props;
+
+        const { imageBookmark } = this.state;
+
+        if (imageBookmark.state === PayloadStates.FETCHING) {
+            return (
+                <IconButton tooltip="Bookmark Image" tooltipPosition="top-center" disabled={true}>
+                    <ToggleStarBorder />
+                </IconButton>
+            );
+        }
+
+        if (imageBookmark.state === PayloadStates.RESOLVED) {
+            return (
+                <IconButton tooltip="Bookmark Image" tooltipPosition="top-center" onClick={this.removeBookmark}>
+                    <ToggleStar color="#FDC228" />
+                </IconButton>
+            );
+        }
+
+        if (
+            imageBookmark.state === PayloadStates.NOT_FOUND ||
+            imageBookmark.state === PayloadStates.DELETED
+        ) {
+            return (
+                <IconButton tooltip="Bookmark Image" tooltipPosition="top-center" onClick={this.bookmarkImage}>
+                    <ToggleStarBorder />
+                </IconButton>
+            );
+        }
+
+        return (
+            <IconButton tooltip="Bookmark Image" tooltipPosition="top-center" disabled={true}>
+                <ToggleStarBorder />
+            </IconButton>
+        );
+    }
+}))
+);

--- a/src/components/images-search/_common/Image/index.js
+++ b/src/components/images-search/_common/Image/index.js
@@ -10,12 +10,13 @@ import moment from 'moment';
 import ColorHash from 'color-hash';
 import { LaunchIcon } from 'cyverse-ui/es/icons';
 import { MediaCardIdentity, MediaCardText, MediaCardMenu } from 'cyverse-ui-next';
-import { ListCard, ListCardDetail, MDBlock } from 'cyverse-ui';
+import { MDBlock } from 'cyverse-ui';
 import ExpandableMediaCard from '../../../../decorators/ExpandableMediaCard';
 import PayloadStates from '../../../../constants/PayloadStates';
 import ImageLaunchDialog from '../../../../dialogs/image/launch';
 import Tags from './Tags';
 import Versions from './Versions';
+import Bookmark from './Bookmark';
 
 export default ExpandableMediaCard()(withRouter(createReactClass({
     displayName: 'Image',
@@ -76,7 +77,7 @@ export default ExpandableMediaCard()(withRouter(createReactClass({
         return (
             <div>
                 <div className="row clickable" style={styles} onClick={this.onClick}>
-                    <div className="col-md-9 col-lg-4">
+                    <div className="col-md-8 col-lg-4">
                         <MediaCardIdentity
                             primaryText={image.data.name}
                             secondaryText={`Created ${moment(image.data.start_date).format('MMM DD YYYY')}`}
@@ -87,10 +88,10 @@ export default ExpandableMediaCard()(withRouter(createReactClass({
                             )}
                         />
                     </div>
-                    <div className="d-none d-lg-block col-lg-6">
+                    <div className="d-none d-lg-block col-lg-5">
                         <MediaCardText text={image.data.description} />
                     </div>
-                    <div className="col-md-3 col-lg-2 text-right">
+                    <div className="col-md-4 col-lg-3 text-right">
                         <div ref="buttons" style={{ paddingTop: '12px', paddingBottom: '12px', display: 'inline-block' }}>
                             <IconButton tooltip="Launch Instance" tooltipPosition="top-center" onClick={() => {
                                 lore.dialog.show(() => {
@@ -105,6 +106,7 @@ export default ExpandableMediaCard()(withRouter(createReactClass({
                             }}>
                                 <LaunchIcon/>
                             </IconButton>
+                            <Bookmark image={image} />
                         </div>
                         <MediaCardMenu ref="menu">
                             <MenuItem
@@ -124,17 +126,6 @@ export default ExpandableMediaCard()(withRouter(createReactClass({
                         <Versions image={image} />
                     </div>
                 ) : null}
-                {/*<ListCardDetail hide={!isExpanded}>*/}
-                    {/*{isExpanded ? (*/}
-                        {/*<div>*/}
-                            {/*<div style={{ marginBottom: '16px' }}>*/}
-                                {/*<MDBlock text={image.data.description} />*/}
-                            {/*</div>*/}
-                            {/*<Tags image={image} />*/}
-                            {/*<Versions image={image} />*/}
-                        {/*</div>*/}
-                    {/*) : null}*/}
-                {/*</ListCardDetail>*/}
             </div>
         );
     }

--- a/src/decorators/InfiniteScrolling.js
+++ b/src/decorators/InfiniteScrolling.js
@@ -47,7 +47,13 @@ export default function(options = {}) {
                 // or deleted, we won't get a change to react to those changes and inform the user.
                 let nextPages = _.remove(pages.map(function(page) {
                     const query = JSON.stringify(page.query);
-                    return storeState[modelName].find[query];
+                    const models = _.assign({}, storeState[modelName].find[query]);
+                    if (options.exclude) {
+                        models.data = _.filter(models.data, function(model) {
+                            return !options.exclude(model);
+                        })
+                    }
+                    return models;
                 }));
 
                 const currentQuery = JSON.stringify(this.props[propName].query.where);

--- a/src/models/imageBookmark.js
+++ b/src/models/imageBookmark.js
@@ -2,6 +2,13 @@ import _ from 'lodash';
 
 export default {
 
+    attributes: {
+        image: {
+            type: 'model',
+            model: 'image'
+        }
+    },
+
     properties: {
 
         /**

--- a/src/utils/cacheUpdated.js
+++ b/src/utils/cacheUpdated.js
@@ -1,0 +1,37 @@
+import _ from 'lodash';
+import PayloadStates from '../constants/PayloadStates';
+
+/**
+ * Tells you whether data has been added or removed. Helpful when determining
+ * whether a resource count has changed.
+ * @param modelName
+ * @param activity
+ */
+
+const count = {};
+const deletedCount = {};
+
+export default function(modelName) {
+    const models = lore.store.getState()[modelName].byId;
+
+    // get the number of models in the store
+    const nextCount = Object.keys(models).length;
+
+    // get the number of models that have been marked as deleted from the store
+    const nextDeletedCount = _.reduce(models, function(count, model) {
+        return model.state === PayloadStates.DELETED ? count + 1 : count;
+    }, 0);
+
+    // signal the data has being changed if either the number of models has changed
+    // or the number of models that have been deleted has changed
+    const hasChanged = (
+        count[modelName] !== nextCount ||
+        deletedCount[modelName] !== nextDeletedCount
+    );
+
+    // update the counts
+    count[modelName] = nextCount;
+    deletedCount[modelName] = nextDeletedCount;
+
+    return hasChanged;
+}


### PR DESCRIPTION
This PR adds the ability to favorite images, including:

* The ability to favorite and unfavorite images
* The number of favorited images in the tabs will update whenever an imageBookmark is added or removed (after the server confirms the change)
* Images will disappear from the bookmarked view if the user removes the bookmark
* The bookmark cannot be clicked until it's fetched from the server, and it can also not be clicked during transition periods (such as while attempting to favorite it, or while in the process of unfavoriting it).

It should be noted however that there is a slight hack when it comes to detecting whether an image is bookmarked, because the /image_bookmarks API endpoint does not currently support the ability to check if a *specific* image is bookmarked. Once it does, the hack can be removed, which is currently contained within `src/components/images-search/_common/Image/Bookmark`.

Also, because the /image_bookmarks endpoint does not support search, the bookmarks list will also display the same images and will not reflect the search term.

# Visual Demonstration
Here is a 10 MB GIF demonstrating the basic user flow (may need to give it a minute to load).

![image-bookmarking](https://user-images.githubusercontent.com/2637399/35722575-2344f598-07b4-11e8-978c-a0a762d21c06.gif)

# Key Callouts
Here are some things worth highlighting.

## Ignore blueprints/actions/destroy and blueprints/lore-actions/destroy
I found a bug in the default `destroy` blueprint that occurs when you try to destroy a model that should also be normalized. I pulled in the blueprints from lore (the two files mentioned) but will delete them as soon as I push the change to npm.

Technically, I could remove the files now (they're not necessary for this PR, only discovered during it's creation) but going to leave them here "just in case" until the fix is on npm.

## New utility called cacheUpdated for detecting when cache has changed for a specific model
There's a tricky problem in this UI which is that we want the count of favorited images to change when a user favorites or unfavorites an image. Troposphere is able to solve it because it makes the assumption that all of a users favorited images are in local cache, and so it can simply keep track of the count. Kaizen is built around "assume everything is paginated", and while we *could* employ that same strategy here, it doesn't scale, and it can't be applied to all scenarios, such as it the user had favorited hundreds or thousands of images.

There were a few approaches I considered:

1. Assume all favorites are in local cache, and count the number that RESOLVED
    * dislike because it doesn't scale to solve the generic problem
2. Override the create/destroy actions to fetch the bookmarks whenever one changes
    * doesn't work when the count is a images matching a search term, because actions don't know what the UI is searching for (one has nothing to do with the other)
3. Pass a callback way down the component hierarchy so the bookmark icon can notify the tabs when the user clicks on it
    * technically, this might/could work, but because the tabs and list are rendered by react-router, which makes it less straight forward (we're not "controlling" them ourselves)
    * also, we only want to update the count once the changes is CONFIRMED by the server, which means we'd need to introduce a component into the Bookmark component that could check and detect when the bookmark action is confirmed by the server and only THEN invoke the callback...so kind of icky
    * additionally, if you run this to the extreme, like a component in the middle of the page needing to inform a notification count in the top navigation, there could be LOTS of components to pass a callback through, which is _obnoxious_ (I guess you could use context though...)
4. Pull in a pub-sub system like [react-broadcast](https://github.com/ReactTraining/react-broadcast) to to be able to emit generic events across the application...but we still have to detect when the request has been completed by the server before emitting the change event
5. Keep track of the timestamp used when the server call was make to get the initial count, and then detect how many imageBookmarks had been created after that point in time
    * in theory, this could work, but it requires resources to have a timestamp of when they were created, and imageBookmarks don't have a created_at date...also, lots of APIs don't (sadly, though they all should) which means this solution can't scale to a generic approach anyway
6. Count the number of imageBookmarks in the store, but NOT to get the count, only to know that _something changed_, and use that to signal to the Tabs component that it should refetch the image favorites.

The 6th option is what I went with, but it turned out to be a generic solution that could work for any model in the store, so I wrote a little utility library.

It also turned out to be the least amount of work _and_ the most generic/scalable solution (seems to cover the full concern space).