### PR TITLE
Add ability to toggle flopback

### DIFF
--- a/assets/sass/media-card.scss
+++ b/assets/sass/media-card.scss
@@ -59,7 +59,7 @@
 }
 
 .status-text {
-    text-transform: capitalize;
+    //text-transform: capitalize;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/blueprints/actions/instanceAction.js
+++ b/blueprints/actions/instanceAction.js
@@ -49,6 +49,20 @@ export default function(options) {
             const originalInstanceActionsPayload = getState('instanceAction.find', instanceActionsQuery);
 
             proxyModel.save().then(function () {
+                if (window.shouldFlopback) {
+                    console.log('flopback!');
+                    dispatch({
+                        type: ActionTypes.update('instance'),
+                        payload: _.merge(model, {
+                            data: {
+                                state: optimisticState
+                            },
+                            state: PayloadStates.RESOLVED
+                        })
+                    });
+                    return;
+                }
+
                 dispatch({
                     type: ActionTypes.update('instance'),
                     payload: _.merge(model, {

--- a/blueprints/actions/volumeAction.js
+++ b/blueprints/actions/volumeAction.js
@@ -44,6 +44,20 @@ export default function(options) {
             };
 
             proxyModel.save().then(function () {
+                if (window.shouldFlopback) {
+                    console.log('flopback!');
+                    dispatch({
+                        type: ActionTypes.update('volume'),
+                        payload: _.merge(model, {
+                            data: {
+                                state: optimisticState
+                            },
+                            state: PayloadStates.RESOLVED
+                        })
+                    });
+                    return;
+                }
+
                 dispatch({
                     type: ActionTypes.update('volume'),
                     payload: _.merge(model, {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ injectTapEventPlugin();
 // the console. Remove this line if you don't want to be able to do that.
 window.lore = lore;
 
+// Set whether the instance and volumes actions should flopback
+window.shouldFlopback = false;
+
 // Hooks
 import auth from 'lore-hook-auth';
 import actions from 'lore-hook-actions';

--- a/src/components/_common/Header/FlopbackToggle.js
+++ b/src/components/_common/Header/FlopbackToggle.js
@@ -1,0 +1,98 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import createReactClass from 'create-react-class';
+import { FlatButton, Toggle } from 'material-ui';
+
+export default createReactClass({
+    displayName: 'FlopbackToggle',
+
+    propTypes: {
+        label: PropTypes.string.isRequired
+    },
+
+    getInitialState() {
+        return {
+            hovered: false,
+            shouldFlopback: window.shouldFlopback
+        }
+    },
+
+    getStyles() {
+        const { hovered, shouldFlopback } = this.state;
+        const isActive = true;
+
+        return {
+            button: {
+                backgroundColor: isActive ? '#075c8c' : '#1572A8',
+                hoverColor: isActive ? '#075c8c' : '#1572A8',
+                style: {
+                    height: '56px',
+                    color: (isActive || hovered) ? 'white' : 'hsla(0, 0%, 100%, 0.7)'
+                },
+                labelStyle: {
+                    paddingLeft: '16px',
+                    color: shouldFlopback ? 'white' : 'rgba(255, 255, 255, 0.7)'
+                }
+            },
+            toggle: {
+                style: {
+                    margin: '6px 0px -8px 25px'
+                },
+                thumbSwitchedStyle: {
+                    backgroundColor: '#FF6F00' // orange
+                    // backgroundColor: '#FF4081', // pink,
+                    // backgroundColor: '#00BCD4' // light blue
+                },
+                trackSwitchedStyle: {
+                    backgroundColor: '#FFB300', // orange
+                    // backgroundColor: '#F48FB1' // pink,
+                    // backgroundColor: '#B2EBF2' // light blue
+                }
+            }
+        }
+    },
+
+    onMouseEnter(event) {
+        this.setState({
+            hovered: true
+        });
+    },
+
+    onMouseLeave(event) {
+        this.setState({
+            hovered: false
+        });
+    },
+
+    onClick() {
+        const { shouldFlopback } = this.state;
+        window.shouldFlopback = !shouldFlopback;
+        this.setState({
+            shouldFlopback: window.shouldFlopback
+        })
+    },
+
+    render: function () {
+        const styles = this.getStyles();
+        const { label } = this.props;
+        const { shouldFlopback } = this.state;
+
+        return (
+            <FlatButton
+                label={label}
+                primary={true}
+                onMouseEnter={this.onMouseEnter}
+                onMouseLeave={this.onMouseLeave}
+                icon={(
+                    <Toggle
+                        toggled={shouldFlopback}
+                        {...styles.toggle}
+                    />
+                )}
+                onClick={this.onClick}
+                {...styles.button}
+            />
+        );
+    }
+
+});

--- a/src/components/_common/Header/index.js
+++ b/src/components/_common/Header/index.js
@@ -14,6 +14,7 @@ import { Link, withRouter } from 'react-router';
 import productLogo from '../../../../assets/images/logo_white.png';
 import HeaderLink from './Link';
 import HeaderAvatar from './Avatar';
+import FlopbackToggle from './FlopbackToggle';
 import IsAuthenticated from '../IsAuthenticated';
 import IsPublic from '../IsPublic';
 import { ContentSave, FileFolder } from 'material-ui/svg-icons';
@@ -107,13 +108,16 @@ export default withRouter(createReactClass({
                             </IsAuthenticated>
                             <HeaderLink label="Images" to="/images" matches={[/^\/images\//]} icon={<ContentSave/>}/>
                         </ToolbarGroup>
+                        <ToolbarGroup style={{ position: 'absolute', right: '180px' }}>
+                            <FlopbackToggle label="Flopback" />
+                        </ToolbarGroup>
                         <ToolbarGroup lastChild={true}>
                             <IsAuthenticated>
                                 <HeaderAvatar/>
-                                <DropDownMenu value='user' onChange={this.onMenuChange} {...styles.dropdownMenu}>
-                                    <MenuItem value='user' primaryText={user.data.username}/>
+                                <DropDownMenu value="user" onChange={this.onMenuChange} {...styles.dropdownMenu}>
+                                    <MenuItem value="user" primaryText={user.data.username}/>
                                     <Divider/>
-                                    <MenuItem value='logout' primaryText="Logout"/>
+                                    <MenuItem value="logout" primaryText="Logout"/>
                                 </DropDownMenu>
                             </IsAuthenticated>
                             <IsPublic>

--- a/src/components/project-instances/Instance/Polling.js
+++ b/src/components/project-instances/Instance/Polling.js
@@ -19,6 +19,7 @@ export default createReactClass({
     componentWillUnmount() {
         if (this.poll) {
             this.poll.stop();
+            this.pollActions.stop();
         }
     },
 

--- a/src/models/instanceV1.js
+++ b/src/models/instanceV1.js
@@ -74,6 +74,7 @@ export default {
                 activity: resp.activity
             };
             return _.pick(resp, [
+                'name',
                 'state'
             ]);
         },


### PR DESCRIPTION
This PR adds the ability to toggle flopback on or off, using a toggle in the top navigation. This PR also:

* Fixes a bug that allowed the actions for an instance to continue being polling even when they instance was no longer in view
* Fixes a bug that allowed volumes to say "Attach to Undefined" instead of "Attached to InstanceName"
* Removes the "capitalize" `text-transform` property from the `status-text` class since it capitalizes *all the words* and not just the first one (which displays text in an unexpected way).

# Visual Demonstration
Here is an 8 MB GIF demonstrating the basic user flow (may need to give it a minute to load).

![flopback-toggle-680px](https://user-images.githubusercontent.com/2637399/35790449-c114edf8-09ff-11e8-991e-d69f552a9427.gif)

# Key Callouts
To make the GIF clear, this is what happens:

1. Flopback is enabled
2. A volume is requested to be detached from an instance
3. The API confirms the request, which closes the dialog.
4. The Volume status is polled from the server, which shows it as being attached, so it "flops back". However this happens *very quickly* so you may not see it occuring (which is why I'm writing this).
5. Flopback is disabled
6. The second volume is requested to be attached to an instance
7. API confirms the request, and the dialog closes
8. The volume action controls what data the application sees, until we have confirmed the volume is *actually being attached* and then it gives control back to the application's normal behavior