### PR TITLE
Switch to progress avatar for instance and volume progress

### DIFF
--- a/assets/sass/media-card.scss
+++ b/assets/sass/media-card.scss
@@ -74,6 +74,10 @@
     top: 10px;
 }
 
+.status-light.updating {
+    opacity: 0.3;
+}
+
 .status-text {
     margin-left: 20px;
 }
@@ -129,4 +133,41 @@
 
 .markdown-body {
     margin-top: 0px !important;
+}
+
+@-webkit-keyframes avatar-breathe {
+    from {
+        opacity: 0.3;
+        filter: alpha(opacity=20)
+    }
+    to {
+        opacity: 0.7;
+        filter: alpha(opacity=100)
+    }
+}
+
+@keyframes avatar-breathe {
+    from {
+        opacity: 0.3;
+        filter: alpha(opacity=20)
+    }
+    to {
+        opacity: 0.7;
+        filter: alpha(opacity=100)
+    }
+}
+
+.avatar-breathe {
+    -webkit-animation-name: avatar-breathe;
+    animation-name: avatar-breathe;
+    -webkit-animation-duration: 1s;
+    animation-duration: 1s;
+    -webkit-animation-delay: .2s;
+    animation-delay: .2s;
+    -webkit-animation-timing-function: cubic-bezier(.73, .005, .42, 1.005);
+    animation-timing-function: cubic-bezier(.73, .005, .42, 1.005);
+    -webkit-animation-iteration-count: infinite;
+    animation-iteration-count: infinite;
+    -webkit-animation-direction: alternate;
+    animation-direction: alternate
 }

--- a/cyverse-ui-next/ProgressAvatar.js
+++ b/cyverse-ui-next/ProgressAvatar.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import muiThemeable from 'material-ui/styles/muiThemeable';
+import { CircularProgress } from 'material-ui';
+
+/**
+ * ProgressAvatar can be used in place of MUI's Avatar as a clear way to inform the user that a process is taking
+ * place on that item as well as what percentage of that process is finished without taking up valuable real estate
+ * and leveraging Avatar being a visual anchor for the item.
+ */
+class ProgressAvatar extends React.Component {
+    static displayName = "ProgressAvatar";
+
+    static propTypes = {
+        /**
+         * Optionally use an image source.
+         */
+        src: PropTypes.string,
+        /**
+         * Optionally use an Icon, expects MUI or CY-UI Icons.
+         */
+        icon: PropTypes.element,
+        /**
+         * The diameter of the Avatar.
+         */
+        size: PropTypes.number,
+        /**
+         * The thickness of the progress bar.
+         */
+        thickness: PropTypes.number,
+        /**
+         * The percentage of progress.
+         */
+        percent: PropTypes.number,
+    };
+
+    static defaultProps = {
+        size: 40,
+        thickness: 3,
+    };
+
+    render() {
+        let {
+            children,
+            progressColor,
+            size,
+            thickness,
+            percent,
+            muiTheme,
+            ...rest
+        } = this.props;
+
+        let { success = "green" } = muiTheme.palette;
+        let opacity = 0;
+        let padding = 0;
+        let value = 0;
+
+        if ( percent < 100 ) {
+            value = percent;
+            opacity = 1;
+            padding = thickness;
+        }
+
+        let strokeColor = progressColor || success;
+
+        return (
+            <div { ...rest }>
+                <div style = {{
+                    position: "relative",
+                    // padding,
+                }}>
+                    <CircularProgress
+                        style={{
+                            opacity,
+                            position: "absolute",
+                            top: "0px",
+                            left: "0px"
+                        }}
+                        mode="determinate"
+                        value={ value }
+                        color={ strokeColor }
+                        size={ size }
+                        thickness={ thickness }
+                    />
+                    {children}
+                </div>
+            </div>
+        );
+    }
+}
+
+export default muiThemeable()(ProgressAvatar);

--- a/cyverse-ui-next/index.js
+++ b/cyverse-ui-next/index.js
@@ -10,6 +10,7 @@ export { default as MediaCardMenu } from './MediaCardMenu';
 export { default as MediaCardPlaceholder } from './MediaCardPlaceholder';
 export { default as MediaCardText } from './MediaCardText';
 export { default as Pill } from './Pill';
+export { default as ProgressAvatar } from './ProgressAvatar';
 export { default as SkeletonText } from './SkeletonText';
 export { default as Stagger } from './Stagger';
 export { default as Tooltip } from './Tooltip';

--- a/src/components/project-instances/Instance/Avatar.js
+++ b/src/components/project-instances/Instance/Avatar.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import { Avatar } from 'material-ui';
+import moment from 'moment';
+import ColorHash from 'color-hash';
+import { ProgressAvatar } from 'cyverse-ui-next';
+import PayloadStates from '../../../constants/PayloadStates';
+import instanceUtils from '../../../utils/instance';
+
+export default createReactClass({
+    displayName: 'Avatar',
+
+    propTypes: {
+        instance: PropTypes.object.isRequired
+    },
+
+    getOpacity() {
+        const { instance } = this.props;
+        const percentComplete = instanceUtils(instance).getPercentComplete();
+        let opacity = 1;
+
+        if (percentComplete < 100) {
+            opacity = 0.5;
+        }
+
+        if (
+            instance.state === PayloadStates.UPDATING  ||
+            instance.state === PayloadStates.MANAGED
+        ) {
+            opacity = 0.3;
+        }
+
+        return opacity;
+    },
+
+    render: function () {
+        const { instance, ...other } = this.props;
+        const percentComplete = instanceUtils(instance).getPercentComplete();
+        const colorHash = new ColorHash();
+        const opacity = this.getOpacity();
+
+        if (percentComplete < 100) {
+            return (
+                <ProgressAvatar percent={percentComplete} {...other}>
+                    <div style={{ padding: '3px' }}>
+                        <Avatar size={34} className="avatar-breathe" backgroundColor={colorHash.hex(instance.id)}>
+                            {_.toUpper(instance.data.name[0])}
+                        </Avatar>
+                    </div>
+                </ProgressAvatar>
+            );
+        }
+
+        return (
+            <div { ...other }>
+                <Avatar backgroundColor={colorHash.hex(instance.id)} style={{ opacity: opacity }}>
+                    {_.toUpper(instance.data.name[0])}
+                </Avatar>
+            </div>
+        );
+    }
+});

--- a/src/components/project-instances/Instance/Status/StatusLight.js
+++ b/src/components/project-instances/Instance/Status/StatusLight.js
@@ -2,6 +2,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import instanceUtils from '../../../../utils/instance';
+import PayloadStates from '../../../../constants/PayloadStates';
 
 export default createReactClass({
     displayName: 'StatusLight',
@@ -28,7 +29,7 @@ export default createReactClass({
         } = this.getInstanceState(instance);
 
         if (activity || status === 'build') {
-            return 'transition breathe';
+            return 'transition';
         }
 
         if (status === 'active') {
@@ -53,9 +54,13 @@ export default createReactClass({
     render: function () {
         const { instance } = this.props;
         const status = this.getLightStatus(instance);
+        const isUpdating = (
+            instance.state === PayloadStates.UPDATING ||
+            instance.state === PayloadStates.MANAGED
+        );
 
         return (
-            <span className={`status-light ${status}`} />
+            <span className={`status-light ${status} ${isUpdating ? 'updating' : ''}`} />
         );
     }
 });

--- a/src/components/project-instances/Instance/Status/index.js
+++ b/src/components/project-instances/Instance/Status/index.js
@@ -32,7 +32,7 @@ export default createReactClass({
         return (
             <div style={{ position: 'relative' }}>
                 <StatusLight instance={instance}/> <StatusText instance={instance} />
-                {showProgress && percentComplete < 100 ? (
+                {false && showProgress && percentComplete < 100 ? (
                     <StatusProgressBar instance={instance} />
                 ) : null}
             </div>

--- a/src/components/project-instances/Instance/index.js
+++ b/src/components/project-instances/Instance/index.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { Avatar } from 'material-ui';
 import moment from 'moment';
 import ColorHash from 'color-hash';
 import { MediaCardIdentity } from 'cyverse-ui-next';
@@ -19,6 +18,7 @@ import ProviderText from './ProviderText';
 import SizeText from './SizeText';
 import Polling from './Polling';
 import InstanceHistory from './InstanceHistory';
+import Avatar from './Avatar';
 
 export default ExpandableMediaCard()(createReactClass({
     displayName: 'Instance',
@@ -36,7 +36,7 @@ export default ExpandableMediaCard()(createReactClass({
 
         if (
             instance.state === PayloadStates.CREATING ||
-            instance.state === PayloadStates.UPDATING ||
+            // volume.state === PayloadStates.UPDATING ||
             instance.state === PayloadStates.DELETING
         ) {
             return {
@@ -78,9 +78,7 @@ export default ExpandableMediaCard()(createReactClass({
                             primaryText={instance.data.name}
                             secondaryText={`Created ${moment(instance.data.start_date).format('MMM DD YYYY')}`}
                             avatar={(
-                                <Avatar backgroundColor={colorHash.hex(instance.id)}>
-                                    {_.toUpper(instance.data.name[0])}
-                                </Avatar>
+                                <Avatar instance={instance}/>
                             )}
                         />
                     </div>

--- a/src/components/project-volumes/Volume/Avatar.js
+++ b/src/components/project-volumes/Volume/Avatar.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import { Avatar } from 'material-ui';
+import moment from 'moment';
+import ColorHash from 'color-hash';
+import { ProgressAvatar } from 'cyverse-ui-next';
+import PayloadStates from '../../../constants/PayloadStates';
+import volumeUtils from '../../../utils/volume';
+
+export default createReactClass({
+    displayName: 'Avatar',
+
+    propTypes: {
+        volume: PropTypes.object.isRequired
+    },
+
+    getOpacity() {
+        const { volume } = this.props;
+        const percentComplete = volumeUtils(volume).getPercentComplete();
+        let opacity = 1;
+
+        if (percentComplete < 100) {
+            opacity = 0.5;
+        }
+
+        if (
+            volume.state === PayloadStates.UPDATING ||
+            volume.state === PayloadStates.MANAGED
+        ) {
+            opacity = 0.3;
+        }
+
+        return opacity;
+    },
+
+    render: function () {
+        const { volume, ...other } = this.props;
+        const percentComplete = volumeUtils(volume).getPercentComplete();
+        const colorHash = new ColorHash();
+        const opacity = this.getOpacity();
+
+        if (percentComplete < 100) {
+            return (
+                <ProgressAvatar percent={percentComplete} {...other}>
+                    <div style={{ padding: '3px' }}>
+                        <Avatar size={34} className="avatar-breathe" backgroundColor={colorHash.hex(volume.id)}>
+                            {_.toUpper(volume.data.name[0])}
+                        </Avatar>
+                    </div>
+                </ProgressAvatar>
+            );
+        }
+
+        return (
+            <div { ...other }>
+                <Avatar backgroundColor={colorHash.hex(volume.id)} style={{ opacity: opacity }}>
+                    {_.toUpper(volume.data.name[0])}
+                </Avatar>
+            </div>
+        );
+    }
+});

--- a/src/components/project-volumes/Volume/Status/StatusLight.js
+++ b/src/components/project-volumes/Volume/Status/StatusLight.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
+import PayloadStates from '../../../../constants/PayloadStates';
 
 export default createReactClass({
     displayName: 'StatusLight',
@@ -11,6 +12,10 @@ export default createReactClass({
 
     render: function () {
         const { volume } = this.props;
+        const isUpdating = (
+            volume.state === PayloadStates.UPDATING ||
+            volume.state === PayloadStates.MANAGED
+        );
 
         if (
             volume.data.state.status === 'available' ||
@@ -22,7 +27,7 @@ export default createReactClass({
         }
 
         return (
-            <span className="status-light transition breathe" />
+            <span className={`status-light transition ${isUpdating ? 'updating': ''}`} />
         );
     }
 });

--- a/src/components/project-volumes/Volume/Status/index.js
+++ b/src/components/project-volumes/Volume/Status/index.js
@@ -27,7 +27,7 @@ export default createReactClass({
         return (
             <div style={{ position: 'relative' }}>
                 <StatusLight volume={volume}/> <StatusText volume={volume} />
-                {showProgress && percentComplete < 100 ? (
+                {false && showProgress && percentComplete < 100 ? (
                     <StatusProgressBar volume={volume} />
                 ) : null}
             </div>

--- a/src/components/project-volumes/Volume/index.js
+++ b/src/components/project-volumes/Volume/index.js
@@ -4,7 +4,6 @@ import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import _ from 'lodash';
-import { Avatar } from 'material-ui';
 import moment from 'moment';
 import ColorHash from 'color-hash';
 import { MediaCardIdentity } from 'cyverse-ui-next';
@@ -17,6 +16,7 @@ import ProviderText from './ProviderText';
 import SizeText from './SizeText';
 import Status from './Status';
 import Polling from './Polling';
+import Avatar from './Avatar';
 
 export default ExpandableMediaCard()(withRouter(createReactClass({
     displayName: 'Volume',
@@ -41,7 +41,7 @@ export default ExpandableMediaCard()(withRouter(createReactClass({
 
         if (
             volume.state === PayloadStates.CREATING ||
-            volume.state === PayloadStates.UPDATING ||
+            // volume.state === PayloadStates.UPDATING ||
             volume.state === PayloadStates.DELETING
         ) {
             return {
@@ -87,9 +87,7 @@ export default ExpandableMediaCard()(withRouter(createReactClass({
                             primaryText={volume.data.name}
                             secondaryText={`Created ${moment(volume.data.start_date).format('MMM DD YYYY')}`}
                             avatar={(
-                                <Avatar backgroundColor={colorHash.hex(volume.id)}>
-                                    {_.toUpper(volume.data.name[0])}
-                                </Avatar>
+                                <Avatar volume={volume} />
                             )}
                         />
                     </div>


### PR DESCRIPTION
This PR updates the media cards for instances and volumes to use the progress avatar instead of the horizontal progress bar below the status. It's unclear if this is want we want (or what the chosen experience should be for the design), but throwing something down based on design discussions so we can at least try something out.

# Visual Demonstration
Here are some gifs of experiences I played with. There are two key considerations I'm trying to capture:

1. Give the user an indication that _something is happening_, like confidence the instance is updating and they don't need to refresh the browser.
2. Give developers a visual indication of how often (and when) the status of the instance/volume is being polled
3. (not included in gifs, but is in PR) a visual indication of when the data flow for the action is no longer being managed (solution for "flopback") - shows you how long it took for task to start being processed

## Concept 1: breath/breate
This concept changes the current experience such both the avatar and the status light are "breathing", with no visual indication of when the instance is being polled:

![progress-avatar-breathe](https://user-images.githubusercontent.com/2637399/35899764-7e893d26-0b8b-11e8-8cd9-2f39b87c3366.gif)

## Concept 2: flicker/breath
This concept changes the current experience such that the avatar has a default reduced opacity, and then "flickers" to show when the instance is being polled (fades at beginning of poll, returns once API call is finished). The status light is breathing.

![progress-avatar-polling-visual](https://user-images.githubusercontent.com/2637399/35899765-7fccfbf0-0b8b-11e8-98ed-ce62f027be22.gif)

## Concept 3: breath/flicker
This concept changes the current experience such that the avatar is "breathing" and the status light "flickers" to show when the instance is being polled.

![progress-avatar-polling-breathing](https://user-images.githubusercontent.com/2637399/35899768-81587c92-0b8b-11e8-9df3-d47134bf6e78.gif)

## Concept 3 implemented in PR
The 3rd concept is what is included in this PR, with a "from scratch" experience shown below, that demonstrates the transition from beginning of an action to when it kicks off and the status switches to "breathing".

![instance-suspend](https://user-images.githubusercontent.com/2637399/35899769-82a90f8a-0b8b-11e8-87f3-02b1f034055b.gif)

# Key Callouts
Here are some things worth highlighting.

## Status light stays faded until action stops managing data flow
When you initiate an action, the status light will stay faded as a visual indicator the action request hasn't made it through celery yet. Once it has, the light be pop back to pull color and starts flickering with each poll request.

## Linear Progress indicator left in code
I'm not removing the linear progress indicator due to the perceived volatility of this experience, and so that it's easy to throw it back in during a demo/conversation to see what it all looks like together (can simply change `false` to `true` and see what it looks like).

## ProgressAvatar modified from cyverse-ui
The progress avatar used is modified version of the one in CyVerse UI , changed so that it accepts an avatar as an argument. This change was made to:

1. Allow the colored version of the avatar to be shown
2. Control the opacity of the avatar, to get the breathing effect

